### PR TITLE
Fixes for the due date picker

### DIFF
--- a/src/css/datepicker.css
+++ b/src/css/datepicker.css
@@ -153,13 +153,13 @@
   background-color: #e8e8e8; }
 
 .datepicker-cell.today:not(.selected) {
-  background-color: #00d1b2; }
+  background-color: #00c44142; }
 
 .datepicker-cell.today:not(.selected):not(.disabled) {
-  color: #fff; }
+  color: inherit; }
 
 .datepicker-cell.today.focused:not(.selected) {
-  background-color: #00c4a7; }
+  background-color: #00c44142; }
 
 .datepicker-cell.range-end:not(.selected), .datepicker-cell.range-start:not(.selected) {
   background-color: #b5b5b5;

--- a/src/render.js
+++ b/src/render.js
@@ -195,7 +195,15 @@ const dueDatePicker = new Datepicker(dueDatePickerInput, {
   autohide: true,
   format: "yyyy-mm-dd",
   clearBtn: true,
-  language: i18next.language
+  language: i18next.language,
+  beforeShowDay: function(date) {
+    let today = new Date();
+    if (date.getDate() == today.getDate() &&
+        date.getMonth() == today.getMonth() &&
+        date.getFullYear() == today.getFullYear()) {
+      return { classes: 'today'};
+    }
+  }
 });
 dueDatePickerInput.placeholder = i18next.t("formSelectDueDate");
 // closes suggestion box on focus

--- a/src/render.js
+++ b/src/render.js
@@ -1983,6 +1983,7 @@ function showForm(todo, templated) {
         if(todo.rec) setRecurrenceInput(todo.rec)
         // if so we paste it into the input field
         if(todo.dueString) {
+          dueDatePicker.setDate(todo.dueString);
           dueDatePickerInput.value = todo.dueString;
           dueDatePickerInput.setAttribute("size", dueDatePickerInput.value.length);
           // only show the recurrence picker when a due date is set

--- a/src/render.js
+++ b/src/render.js
@@ -229,6 +229,13 @@ dueDatePickerInput.addEventListener('changeDate', function (e, details) {
     if(matomoEvents) _paq.push(["trackEvent", "Form", "Datepicker used to add date to input"]);
   }
 });
+// Actually clear the due date after clicking the Clear button
+document.querySelector(".datepicker .clear-btn").addEventListener('click', function (e) {
+  let todo = new TodoTxtItem(modalFormInput.value, [ new DueExtension(), new RecExtension() ]);
+  todo.due = undefined;
+  todo.dueString = undefined;
+  modalFormInput.value = todo.toString();
+});
 // ########################################################################################################################
 // PREP FOR TABLE RENDERING
 // ########################################################################################################################

--- a/src/scss/datepicker.scss
+++ b/src/scss/datepicker.scss
@@ -154,13 +154,13 @@
   background-color: #e8e8e8; }
 
 .datepicker-cell.today:not(.selected) {
-  background-color: #00d1b2; }
+  background-color: #00c44142; }
 
 .datepicker-cell.today:not(.selected):not(.disabled) {
-  color: #fff; }
+  color: inherit; }
 
 .datepicker-cell.today.focused:not(.selected) {
-  background-color: #00c4a7; }
+  background-color: #00c44142; }
 
 .datepicker-cell.range-end:not(.selected), .datepicker-cell.range-start:not(.selected) {
   background-color: #b5b5b5;


### PR DESCRIPTION
This pull request fixes the following issues with the due date picker:

- when opening the date picker, the initial selection doesn't match the taks's due date
- clicking the Clear button doesn't remove the due date from the text input field (reported in #32)
- sometimes a wrong or missing date is displayed in the `dueDatePickerInput` if the user clicks outside it
- there is no indication of the current day in the calendar, and in combination with the first issue, it's quite confusing

Also, the current day is indicated in a cell with a light green background. It's not too distracting from the actual selection.