### PR TITLE
fix month, year recurrence periods to be more accurate

### DIFF
--- a/src/js/recurrences.mjs
+++ b/src/js/recurrences.mjs
@@ -58,6 +58,7 @@ function generateRecurrence(todo) {
 function getRecurrenceDate(due, recurrence) {
   let recSplit = splitRecurrence(recurrence);
   let days = 0;
+  let months = 0;
   switch (recSplit.period) {
     case "d":
       days = 1;
@@ -66,11 +67,19 @@ function getRecurrenceDate(due, recurrence) {
       days = 7;
       break;
     case "m":
-      days = 30;
+      months = 1;
       break;
     case "y":
-      days = 365;
+      months = 12;
       break;
+  }
+  if (months > 0) {
+    let due_month = due.getMonth() + recSplit.mul * months;
+    let due_year = due.getFullYear() + Math.floor(due_month/12);
+    due_month = due_month % 12;
+    let monthlen = new Date(due_year, due_month+1, 0).getDate();
+    let due_day = Math.min(due.getDate(), monthlen);
+    return new Date(due_year, due_month, due_day);
   }
   due = due.getTime();
   due += 1000 * 60 * 60 * 24 * recSplit.mul * days;


### PR DESCRIPTION
This fixes issue #136, which is a bug in the length of month and year recurrence intervals.

Sleek treats a month as 30 days and a year as 365 days.  Of course, the length of a month actually varies from 28 to 31 days and years vary in length because of leap years, so to have accurate recurrence intervals we need to use the length of whatever months are involved.  For instance, if we go from a due date of Feb 20, 2021 and add one month, the existing code in sleek would always add 30 days, resulting in Mar 22, 2021.   But using the actual length of the month the fix in this PR would add 28 days, resulting in Mar 20, 2021.  Similarly, from due date of Mar 20, 2021 adding one month with the existing code would give Apr 19, 2021, but with the fix in this PR would give Apr 20, 2021.