### PR TITLE
add user pref to enable/disable generation of all past recurrences

### DIFF
--- a/src/js/todos.mjs
+++ b/src/js/todos.mjs
@@ -139,7 +139,7 @@ function generateTable(groups) {
         if(!todo.rec) {
           todo.rec = null;
         // if item is due today or in the past and has recurrence it will be duplicated
-        } else if(todo.due && todo.rec && !todo.complete && (isToday(todo.due) || isPast(todo.due))) {
+        } else if(userData.generatePastRecurrences && todo.due && todo.rec && !todo.complete && (isToday(todo.due) || isPast(todo.due))) {
           generateRecurrence(todo).then(response => {
             console.log(response);
           }).catch(error => {

--- a/src/main.js
+++ b/src/main.js
@@ -240,6 +240,7 @@ const createWindow = async function() {
       if(typeof userData.data.sortCompletedLast != "boolean") userData.set("sortCompletedLast", false);
       if(typeof userData.data.sortBy != "string") userData.set("sortBy", "priority");
       if(typeof userData.data.zoom != "string") userData.set("zoom", "100");
+      if(typeof userData.data.generatePastRecurrences != "boolean") userData.set("generatePastRecurrences", true);
       if(typeof appData.tray != "boolean") appData.tray = false;
       if(!Array.isArray(userData.data.dismissedNotifications)) userData.set("dismissedNotifications", []);
       if(!Array.isArray(userData.data.dismissedMessages)) userData.set("dismissedMessages", []);


### PR DESCRIPTION
This PR provides a new user preference generatePastRecurrences which defaults to true to preserve the existing behavior. However if you set it to false in the user-preferences.json you will get the new behavior of not generating past recurrences until the original task is marked completed. Only one recurrence task will be generated each time the existing task is completed. This is the behavior that @rzelnik was requesting in #147 I think.

@ransome1, as you suggested, it might make sense to make false the default if more people prefer that. I certainly do. If you think anybody is depending on the old behavior, you could keep the user preference, but just change the default.

(Note: I screwed up my first attempt at this PR which was #148, so this one supercedes #148.)