### PR TITLE
Allow sugar date formats in the edit todo field

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ A prioritized backlog of new features and known issues can be found <a href="htt
 - i18next: https://github.com/i18next/i18next
 - Matomo: https://github.com/matomo-org/matomo
 - chokidar: https://github.com/paulmillr/chokidar
+- Sugar: https://github.com/andrewplummer/Sugar

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "i18next-fs-backend": "^1.1.1",
     "jstodotxt": "^0.9.0",
     "marked": "^2.0.3",
+    "sugar": "^2.0.6",
     "vanillajs-datepicker": "^1.1.4"
   },
   "devDependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -506,7 +506,7 @@
             <tr>
               <td><a href="https://github.com/matomo-org/matomo" target="_blank">Matomo</a></td>
               <td><a href="https://github.com/paulmillr/chokidar" target="_blank">chokidar</a></td>
-              <td></td>
+              <td><a href="https://github.com/andrewplummer/Sugar" target="_blank">Sugar</a></td>
               <td></td>
             </tr>
           </table>
@@ -727,6 +727,7 @@
     </section>
     <script defer src="../node_modules/jstodotxt/jsTodoExtensions.js"></script>
     <script defer src="../node_modules/jstodotxt/jsTodoTxt.js"></script>
+    <script defer src="../node_modules/sugar/dist/sugar.min.js"></script>
     <script defer src="../node_modules/marked/marked.min.js"></script>
     <script defer type="module" src="render.js"></script>
   </body>

--- a/src/js/datePicker.mjs
+++ b/src/js/datePicker.mjs
@@ -1,7 +1,7 @@
 "use strict";
 import { translations, userData, _paq } from "../render.js";
 import { resizeInput } from "./form.mjs";
-import { RecExtension } from "./todotxtExtensions.mjs";
+import { RecExtension, SugarDueExtension } from "./todotxtExtensions.mjs";
 import Datepicker from "../../node_modules/vanillajs-datepicker/js/Datepicker.js";
 import de from "../../node_modules/vanillajs-datepicker/js/i18n/locales/de.js";
 import it from "../../node_modules/vanillajs-datepicker/js/i18n/locales/it.js";
@@ -19,7 +19,7 @@ datePickerInput.addEventListener("changeDate", function (e) {
   // we only update the object if there is a date selected. In case of a refresh it would throw an error otherwise
   if(e.detail.date) {
     // generate the object on what is written into input, so we don't overwrite previous inputs of user
-    let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+    let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
     todo.due = new Date(e.detail.date);
     todo.dueString = new Date(e.detail.date.getTime() - (e.detail.date.getTimezoneOffset() * 60000 )).toISOString().split("T")[0];
     // if suggestion box was open, it needs to be closed
@@ -51,7 +51,7 @@ const datePicker = new Datepicker(datePickerInput, {
   }
 });
 document.querySelector(".datepicker .clear-btn").onclick = function() {
-  let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+  let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
   todo.due = undefined;
   todo.dueString = undefined;
   document.getElementById("modalFormInput").value = todo.toString();

--- a/src/js/form.mjs
+++ b/src/js/form.mjs
@@ -1,6 +1,6 @@
 "use strict";
 import { showMore, resetModal, handleError, userData, setUserData, translations, _paq } from "../render.js";
-import { RecExtension } from "./todotxtExtensions.mjs";
+import { RecExtension, SugarDueExtension } from "./todotxtExtensions.mjs";
 import { generateFilterData } from "./filters.mjs";
 import { items, item, setTodoComplete } from "./todos.mjs";
 import { datePickerInput } from "./datePicker.mjs";
@@ -179,7 +179,7 @@ function setPriority(priority) {
         });
       }
     }
-    let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+    let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
     if((priority==="down" || priority==="up") && !todo.priority) {
       todo.priority = "A";
     } else if(priority==="up" && todo.priority!="a") {
@@ -206,7 +206,7 @@ function setPriority(priority) {
 }
 function setDueDate(days) {
   try {
-    const todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+    const todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
     if(days===0) {
       todo.due = undefined;
       todo.dueString = undefined;
@@ -244,7 +244,7 @@ function show(todo, templated) {
       // replace invisible multiline ascii character with new line
       todo = todo.replaceAll(String.fromCharCode(16),"\r\n");
       // we need to check if there already is a due date in the object
-      todo = new TodoTxtItem(todo, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+      todo = new TodoTxtItem(todo, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
       // set the priority
       setPriority(todo.priority);
       //
@@ -324,7 +324,7 @@ function submitForm() {
       const index = items.objects.map(function(item) {return item.toString(); }).indexOf(modalForm.getAttribute("data-item"));
       // create a todo.txt object
       // replace new lines with spaces (https://stackoverflow.com/a/34936253)
-      let todo = new TodoTxtItem(modalForm.elements[0].value.replaceAll(/[\r\n]+/g, String.fromCharCode(16)), [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+      let todo = new TodoTxtItem(modalForm.elements[0].value.replaceAll(/[\r\n]+/g, String.fromCharCode(16)), [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
       // check and prevent duplicate todo
       if(items.objects.map(function(item) {return item.toString(); }).indexOf(todo.toString())!=-1) {
         modalFormAlert.innerHTML = translations.formInfoDuplicate;
@@ -344,7 +344,7 @@ function submitForm() {
     } else if(modalForm.getAttribute("data-item")==null && modalForm.elements[0].value!="") {
       // in case there hasn't been a passed data item, we just push the input value as a new item into the array
       // replace new lines with spaces (https://stackoverflow.com/a/34936253)
-      let todo = new TodoTxtItem(modalForm.elements[0].value.replaceAll(/[\r\n]+/g, String.fromCharCode(16)), [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+      let todo = new TodoTxtItem(modalForm.elements[0].value.replaceAll(/[\r\n]+/g, String.fromCharCode(16)), [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
       // we add the current date to the start date attribute of the todo.txt object
       todo.date = new Date();
       // check and prevent duplicate todo

--- a/src/js/recurrencePicker.mjs
+++ b/src/js/recurrencePicker.mjs
@@ -85,7 +85,7 @@ function showRecurrences() {
   recurrencePickerContainer.focus();
   recurrencePickerContainer.classList.toggle("is-active");
   // get object from current input
-  let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
+  let todo = new TodoTxtItem(document.getElementById("modalFormInput").value, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]);
   let recSplit = recurrences.splitRecurrence(todo.rec);
   setRecurrenceOptionLabels(recSplit.mul);
   recurrencePickerSpinner.value = recSplit.mul;

--- a/src/js/todos.mjs
+++ b/src/js/todos.mjs
@@ -1,6 +1,6 @@
 "use strict";
 import { userData, appData, handleError, translations, setUserData, _paq, startBuilding } from "../render.js";
-import { RecExtension } from "./todotxtExtensions.mjs";
+import { RecExtension, SugarDueExtension } from "./todotxtExtensions.mjs";
 import { categories } from "./filters.mjs";
 import { generateRecurrence } from "./recurrences.mjs";
 import { convertDate, isToday, isTomorrow, isPast } from "./date.mjs";
@@ -109,7 +109,7 @@ function configureTodoTableTemplate(append) {
 }
 function generateItems(content) {
   try {
-    items = { objects: TodoTxt.parse(content, [ new DueExtension(), new RecExtension(), new HiddenExtension() ]) }
+    items = { objects: TodoTxt.parse(content, [ new SugarDueExtension(), new RecExtension(), new HiddenExtension() ]) }
     items.objects = items.objects.filter(function(item) {
       if(!item.text) return false;
       return true;
@@ -450,7 +450,7 @@ function setTodoComplete(todo) {
     // in case edit form is open, text has changed and complete button is pressed, we do not fall back to the initial value of todo but instead choose input value
     if(modalForm.elements[0].value) todo = modalForm.elements[0].value;
     // first convert the string to a todo.txt object
-    todo = new TodoTxtItem(todo, [ new DueExtension(), new RecExtension(), new HiddenExtension() ]);
+    todo = new TodoTxtItem(todo, [ new SugarDueExtension(), new RecExtension(), new HiddenExtension() ]);
     // get index of todo
     const index = items.objects.map(function(item) {return item.toString(); }).indexOf(todo.toString());
     // mark item as in progress
@@ -493,7 +493,7 @@ function setTodoDelete(todo) {
     // in case edit form is open, text has changed and complete button is pressed, we do not fall back to the initial value of todo but instead choose input value
     if(modalForm.elements[0].value) todo = modalForm.elements[0].value;
     // first convert the string to a todo.txt object
-    todo = new TodoTxtItem(todo, [ new DueExtension(), new RecExtension(), new HiddenExtension() ]);
+    todo = new TodoTxtItem(todo, [ new SugarDueExtension(), new RecExtension(), new HiddenExtension() ]);
     // get index of todo
     const index = items.objects.map(function(item) {return item.toString(); }).indexOf(todo.toString());
     // Delete item
@@ -534,7 +534,7 @@ async function archiveTodos() {
     const getContentFromDoneFile = new Promise(function(resolve, reject) {
       window.api.send("getContent", doneFile());
       return window.api.receive("getContent", (content) => {
-        //resolve(TodoTxt.parse(content, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]));
+        //resolve(TodoTxt.parse(content, [ new SugarDueExtension(), new HiddenExtension(), new RecExtension() ]));
         resolve(content);
       });
     });

--- a/src/js/todotxtExtensions.mjs
+++ b/src/js/todotxtExtensions.mjs
@@ -24,7 +24,7 @@ SugarDueExtension.prototype.parsingFunction = function (line) {
 	var indexDueKeyword = line.indexOf("due:");
 
 	// Find keyword due
-	if (indexDueKeyword > 0) {
+	if (indexDueKeyword >= 0) {
 		var stringAfterDue = line.substr(indexDueKeyword + 4)
 		var words = stringAfterDue.split(" ");
 		var match = null;

--- a/src/js/todotxtExtensions.mjs
+++ b/src/js/todotxtExtensions.mjs
@@ -30,7 +30,7 @@ SugarDueExtension.prototype.parsingFunction = function (line) {
 		var match = null;
 		
 		// Try to parse a valid date until the end of the text
-		for (var i = 1; i <= words.length; i++) {
+		for (var i = Math.max(5, words.length); i > 0; i--) {
 			match = words.slice(0, i).join(" ");
 			dueDate = Sugar.Date.create(match);
 			if (Sugar.Date.isValid(dueDate)) {

--- a/src/js/todotxtExtensions.mjs
+++ b/src/js/todotxtExtensions.mjs
@@ -15,18 +15,29 @@ RecExtension.prototype.parsingFunction = function(line) {
 
 export { RecExtension };
 
+// TODO Use SugarDueExtension only for parsing from input field otherwise normal DueExtension
 function SugarDueExtension() {
 	this.name = "due";
 }
 SugarDueExtension.prototype = new TodoTxtExtension();
-SugarDueExtension.prototype.parsingFunction = function(line) {
+SugarDueExtension.prototype.parsingFunction = function (line) {
 	var dueDate = null;
-	var dueRegex = /due:([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})\s*/;
-	var matchDue = dueRegex.exec(line);
-	if ( matchDue !== null ) {
-		var datePieces = matchDue[1].split('-');
-		dueDate = new Date( datePieces[0], datePieces[1] - 1, datePieces[2] );
-		return [dueDate, line.replace(dueRegex, ''), matchDue[1]];
+	var indexDueKeyword = line.indexOf("due:");
+
+	// Find keyword due
+	if (indexDueKeyword > 0) {
+		var stringAfterDue = line.substr(indexDueKeyword + 4)
+		var words = stringAfterDue.split(" ");
+		var match = null;
+		
+		// Try to parse a valid date until the end of the text
+		for (var i = 1; i <= words.length; i++) {
+			match = words.slice(0, i).join(" ");
+			dueDate = Sugar.Date.create(match);
+			if (Sugar.Date.isValid(dueDate)) {
+				return [dueDate, line.replace("due:" + match, ''), match];
+			}
+		}
 	}
 	return [null, null, null];
 };

--- a/src/js/todotxtExtensions.mjs
+++ b/src/js/todotxtExtensions.mjs
@@ -15,7 +15,6 @@ RecExtension.prototype.parsingFunction = function(line) {
 
 export { RecExtension };
 
-// TODO Use SugarDueExtension only for parsing from input field otherwise normal DueExtension
 function SugarDueExtension() {
 	this.name = "due";
 }
@@ -35,7 +34,7 @@ SugarDueExtension.prototype.parsingFunction = function (line) {
 			match = words.slice(0, i).join(" ");
 			dueDate = Sugar.Date.create(match);
 			if (Sugar.Date.isValid(dueDate)) {
-				return [dueDate, line.replace("due:" + match, ''), match];
+				return [dueDate, line.replace("due:" + match, ''), Sugar.Date.format(dueDate, '%Y-%m-%d')];
 			}
 		}
 	}

--- a/src/js/todotxtExtensions.mjs
+++ b/src/js/todotxtExtensions.mjs
@@ -14,3 +14,21 @@ RecExtension.prototype.parsingFunction = function(line) {
 };
 
 export { RecExtension };
+
+function SugarDueExtension() {
+	this.name = "due";
+}
+SugarDueExtension.prototype = new TodoTxtExtension();
+SugarDueExtension.prototype.parsingFunction = function(line) {
+	var dueDate = null;
+	var dueRegex = /due:([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})\s*/;
+	var matchDue = dueRegex.exec(line);
+	if ( matchDue !== null ) {
+		var datePieces = matchDue[1].split('-');
+		dueDate = new Date( datePieces[0], datePieces[1] - 1, datePieces[2] );
+		return [dueDate, line.replace(dueRegex, ''), matchDue[1]];
+	}
+	return [null, null, null];
+};
+
+export { SugarDueExtension };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5579,6 +5579,18 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+sugar-core@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/sugar-core/-/sugar-core-2.0.6.tgz#785e0cd64aa7302ea54d47bc1213efe52c006270"
+  integrity sha512-YmLFysR3Si6RImqL1+aB6JH81EXxvXn5iXhPf2PsjfoUYEwCxFDYCQY+zC3WqviuGWzxFaSkkJvkUE05Y03L5Q==
+
+sugar@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/sugar/-/sugar-2.0.6.tgz#aa08e389add27109fb35718598313e0503a4fc39"
+  integrity sha512-s0P2/pjJtAD9VA44+2Gqm3NdC4v+08melA6YubOxzshu628krTbn95/M2GWMrI9rYspZMpYBIrChR46fjQ7xsQ==
+  dependencies:
+    sugar-core "^2.0.0"
+
 sumchecker@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"


### PR DESCRIPTION
This uses sugar for parsing due dates in the todo description.

Two things that should be mentioned:
* In the todo.txt file the date is written in standard format in order to not interfere with using more than one word for key:value extensions - see https://github.com/todotxt/todo.txt#additional-file-format-definitions
* Currently the enhancement just parses English date strings (e.g. tomorrow)