### PR TITLE
add support for prefix match in project and context

### DIFF
--- a/src/js/filterlang.pegjs
+++ b/src/js/filterlang.pegjs
@@ -29,12 +29,10 @@ boolExpr
 
 project
     = "+" left:name      { return ["++", left]; }
-    / "+*"               { return ["++", "*"]; }
     / "+"               { return ["++", "*"]; }
 
 context
     = "@" left:name      { return ["@@", left]; }
-    / "@*"               { return ["@@", "*"]; }
     / "@"               { return ["@@", "*"]; }
 
 OrOp
@@ -116,10 +114,10 @@ number
     = [0-9]+ { return text(); }
     
 StringLiteral "string"
-    = '"' chars:DoubleStringCharacter* '"' {
+    = '"' chars:DoubleStringCharacter* '"'? {
         return chars.join("");
     }
-    / "'" chars:SingleStringCharacter* "'" {
+    / "'" chars:SingleStringCharacter* "'"? {
         return chars.join("");
     }
 
@@ -135,7 +133,7 @@ RegexLiteral "regex"
     = "/" chars:RegexCharacter* "/"  "i" {
         return new RegExp(chars.join(""), "i");
     }
-    / "/" chars:RegexCharacter* "/" {
+    / "/" chars:RegexCharacter* "/"? {
         return new RegExp(chars.join(""));
     }
 
@@ -148,6 +146,7 @@ SourceCharacter
   
 name
 	= '"' [a-zA-Z_][a-zA-Z_0-9]* '"'    { return text(); }
+	/ [a-zA-Z_][a-zA-Z_0-9]*  '"'       { return '"' + text(); }
 	/ [a-zA-Z_][a-zA-Z_0-9]*            { return text(); }
 
 _ "whitespace"

--- a/src/js/filterlang.pegjs
+++ b/src/js/filterlang.pegjs
@@ -4,6 +4,7 @@
 
 filterQuery
     = _ left:orExpr _  { return left; }
+    / _ { return []; }
 
 orExpr
     = left:andExpr _ OrOp _ right:orExpr { return left.concat(right, ["||"]); }
@@ -29,10 +30,12 @@ boolExpr
 project
     = "+" left:name      { return ["++", left]; }
     / "+*"               { return ["++", "*"]; }
+    / "+"               { return ["++", "*"]; }
 
 context
     = "@" left:name      { return ["@@", left]; }
     / "@*"               { return ["@@", "*"]; }
+    / "@"               { return ["@@", "*"]; }
 
 OrOp
     = "||"
@@ -144,7 +147,8 @@ SourceCharacter
     = .
   
 name
-	= [a-zA-Z_][a-zA-Z_0-9]*     { return text(); }
+	= '"' [a-zA-Z_][a-zA-Z_0-9]* '"'    { return text(); }
+	/ [a-zA-Z_][a-zA-Z_0-9]*            { return text(); }
 
 _ "whitespace"
   = [ \t\n\r]*

--- a/src/js/filterquery.mjs
+++ b/src/js/filterquery.mjs
@@ -4,6 +4,9 @@
 // specifically for todo.txt searching and filtering.
 
 function runQuery(item, compiledQuery) {
+  if (!compiledQuery) {
+    return true;  // a null query matches everything
+  }
   let stack = [];
   let operand1 = false;
   let operand2 = false;
@@ -69,16 +72,26 @@ function runQuery(item, compiledQuery) {
         next = q.shift();
         if (next == "*") {
           stack.push(item.projects ? true : false);
+        } else if (next.startsWith('"')) {
+          stack.push(item.projects && item.projects.includes(next.slice(1,-1)));
         } else {
-          stack.push(item.projects && item.projects.includes(next));
+          // match the prefix of the project name
+          stack.push(item.projects && item.projects.findIndex(function(p) {
+            return p.startsWith(next);
+          }) > -1);
         }
         break;
       case "@@":
         next = q.shift();
         if (next == "*") {
           stack.push(item.contexts ? true : false);
+        } else if (next.startsWith('"')) {
+          stack.push(item.contexts && item.contexts.includes(next.slice(1,-1)));
         } else {
-          stack.push(item.contexts && item.contexts.includes(next));
+          // match the prefix of the context name
+          stack.push(item.contexts && item.contexts.findIndex(function(c) {
+            return c.startsWith(next);
+          }) > -1);
         }
         break;
       case "||":


### PR DESCRIPTION
This pull request adds filter query language support for prefix matching in the project and context.

To  itemize the changes:

    if you type just ? it will make a null query which matches everything.
    if you type ?+ it will match everything with a project (just like +* does).
    if you type ?+foo it will match projects foo and foobar.
    if you type ?"+foo" it will match only the project foo.
    as before, if you are in the middle of some syntax that is broken, it will match nothing, to show you that the query is not finished yet.
