### PR TITLE
fix bug in finding todo in items array because of inconsistent extens…

### DIFF
--- a/src/js/todos.mjs
+++ b/src/js/todos.mjs
@@ -100,7 +100,7 @@ function configureTodoTableTemplate(append) {
 }
 function generateItems(content) {
   try {
-    items = { objects: TodoTxt.parse(content, [ new DueExtension(), new RecExtension(), new HiddenExtension() ]) }
+    items = { objects: TodoTxt.parse(content, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]) }
     items.objects = items.objects.filter(function(item) {
       if(!item.text) return false;
       return true;
@@ -430,7 +430,7 @@ function sortTodoData(group) {
 function setTodoComplete(todo) {
   try {
     // first convert the string to a todo.txt object
-    todo = new TodoTxtItem(todo, [ new RecExtension(), new DueExtension(), new HiddenExtension() ]);
+    todo = new TodoTxtItem(todo, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
     // get index of todo
     const index = items.objects.map(function(item) {return item.toString(); }).indexOf(todo.toString());
     // mark item as in progress
@@ -473,7 +473,7 @@ function setTodoDelete(todo) {
     // in case edit form is open, text has changed and complete button is pressed, we do not fall back to the initial value of todo but instead choose input value
     if(modalForm.elements[0].value) todo = modalForm.elements[0].value;
     // first convert the string to a todo.txt object
-    todo = new TodoTxtItem(todo);
+    todo = new TodoTxtItem(todo, [ new DueExtension(), new HiddenExtension(), new RecExtension() ]);
     // get index of todo
     const index = items.objects.map(function(item) {return item.toString(); }).indexOf(todo.toString());
     // Delete item


### PR DESCRIPTION
Fixes bug described in issue #169 as described below.

The bug arises because of the method used to find a todo in sleek.  Since todo.txt tasks don't have unique IDs, tasks are located by doing a string match of the results of `todo.toString()` which converts the task object to a string, for instance:

```
const index = items.objects.map(function(item) {return item.toString(); }).indexOf(todo.toString());
```
Obviously this only works if the todo.toString() always returns the same string for the same object.  But the toString is inherited from jsTodoTxt and its behavior depends on the list of jsTodoTxt extensions.  That is, the exact list of extensions, including the order in the list, and it is the list of extensions from the jsTodoTxt call that created each object.  And unfortunately, `todos.mjs` is not consistent in the list of extensions passed in the `new TodoTxtItem` and `TodoTxt.parse` calls.  Since the list of extensions is different or in different order in each call, the string returned by `toString` has the `due` and `rec` tags in different orders, so the `indexOf` finds nothing.

This PR fixes the bug by specifying the same set of extensions `[ new DueExtension(), new HiddenExtension(), new RecExtension() ]` in each of the three calls in `todos.mjs`.

Note that there are 8 other calls in three files: `datePicker.mjs`, `form.mjs`, and `recurrencePicker.mjs` and four of those have inconsistent extension lists as well.  However, it appears to me after examining the code that these calls won't result in a bug because no string-matching indexOf is being performed on those TodoTxt objects.
