### PR TITLE
Adapt search box to compact view

### DIFF
--- a/src/scss/compact.scss
+++ b/src/scss/compact.scss
@@ -9,7 +9,7 @@
     padding-top: 0.5em;
     input[type="search"],
     input[type="text"] {
-      padding: 1.5em 1em 1.5em 1.5em;
+      padding: 0.75em 1em 0.75em 1.5em;
     }
     input::placeholder,
     textarea::placeholder {
@@ -45,10 +45,10 @@
     }
     i.fa-search,
     .todoTableSearchQuestionmark {
-      top: 0.65em;
+      top: 0.37em;
     }
     #todoTableSearchAddTodo {
-      top: 2.2em;
+      top: 1.70em;
       i {
         display: none;
       }


### PR DESCRIPTION
Currently, padding around the search box is not affected when Compact View is toggled on and this results in some size mismatch. This edit updates compact.scss to align the proportions of search with its surrounding elements. Before and after images are below.

![before](https://user-images.githubusercontent.com/74933793/149860706-74113a74-0604-46a2-8c5b-5be569f936d1.png)

![after](https://user-images.githubusercontent.com/74933793/149860817-46ea0299-48e8-41d8-bbd0-aa1f2a88f8c0.png)

