### PR TITLE
feature/add removable-media plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,7 @@ apps:
     - home
     - browser-support
     - network
+    - removable-media
 parts:
   sleek:
     plugin: nil


### PR DESCRIPTION
My todo.txt are stored on a mounted drive in /mnt/. By adding this plug, Sleek is able to get to that directory.