### PR TITLE
Add priority options to todo context menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -776,6 +776,10 @@
     <div id="todoContext" role="menu" tabindex="0">
       <div class="card">
         <div class="card-content">
+          <div class="horizontal">
+            <a id="todoContextPriorityIncrease" class="dropdown-item" tabindex="0"><i class="fas fa-arrow-up"></i></a>
+            <a id="todoContextPriorityDecrease" class="dropdown-item" tabindex="0"><i class="fas fa-arrow-down"></i></a>
+          </div>
           <a id="todoContextUseAsTemplate" class="dropdown-item" tabindex="0"></a>
           <a id="todoContextCopy" href="#" class="dropdown-item" tabindex="0"></a>
           <a id="todoContextDelete" class="dropdown-item" tabindex="0"></a>

--- a/src/js/todos.mjs
+++ b/src/js/todos.mjs
@@ -22,6 +22,8 @@ const todoContext = document.getElementById("todoContext");
 const todoContextDelete = document.getElementById("todoContextDelete");
 const todoContextCopy = document.getElementById("todoContextCopy");
 const todoContextUseAsTemplate = document.getElementById("todoContextUseAsTemplate");
+const todoContextPriorityIncrease = document.getElementById("todoContextPriorityIncrease");
+const todoContextPriorityDecrease = document.getElementById("todoContextPriorityDecrease");
 const todoTable = document.getElementById("todoTable");
 const todoTableBodyCellArchiveTemplate = document.createElement("span");
 const todoTableBodyCellCheckboxTemplate  = document.createElement("div");
@@ -547,9 +549,69 @@ function createTodoContext(todoTableRow) {
       // trigger matomo event
       if(userData.matomoEvents) _paq.push(["trackEvent", "Todo-Table-Context", "Click on Delete"]);
     }
+    const changePriority = async function(direction) {
+      // get index of todo
+      const index = await items.objects.map(function(object) {return object.toString(); }).indexOf(todoTableRow.getAttribute("data-item"));
+
+      // retrieve todo object
+      const todo = items.objects[index]
+
+      // abort if todo has no priority set
+      if (!todo.priority) return false;
+
+      const currentPriority = todo.priority
+      if (direction < 0) {
+        if (currentPriority !== "Z") {
+          todo.priority = String.fromCharCode(currentPriority.charCodeAt(0) + 1);
+        } else {
+          return false;
+        }
+      } else if (direction > 0) {
+        if (currentPriority !== "A") {
+          todo.priority = String.fromCharCode(currentPriority.charCodeAt(0) - 1);
+        } else {
+          return false;
+        }
+      }
+
+      //write the data to the file
+      window.api.send("writeToFile", [items.objects.join("\n").toString() + "\n"]);
+
+      todoContext.classList.toggle("is-active");
+      todoContext.removeAttribute("data-item");
+    }
 
     todoContext.setAttribute("data-item", todoTableRow.getAttribute("data-item"))
+    todoContext.setAttribute("data-item", todoTableRow.getAttribute("data-item"))
+
+    // get index of todo
+    const index = items.objects.map(function(object) {return object.toString(); }).indexOf(todoTableRow.getAttribute("data-item"));
+
+    // show/hide priority change buttons
+    if (items.objects[index].priority) {
+      todoContextPriorityIncrease.classList.remove("is-hidden")
+      todoContextPriorityDecrease.classList.remove("is-hidden")
+    } else {
+      todoContextPriorityIncrease.classList.add("is-hidden")
+      todoContextPriorityDecrease.classList.add("is-hidden")
+    }
     
+    // click on increse priority option
+    todoContextPriorityIncrease.onclick = function() {
+      changePriority(1);
+    }
+    todoContextPriorityIncrease.onkeypress = function(event) {
+      if(event.key !== "Enter") return false;
+      changePriority(1);
+    }
+    // click on decrease priority option
+    todoContextPriorityDecrease.onclick = function() {
+      changePriority(-1);
+    }
+    todoContextPriorityDecrease.onkeypress = function(event) {
+      if(event.key !== "Enter") return false;
+      changePriority(-1);
+    }
     // click on use as template option
     todoContextUseAsTemplate.onclick = function() {
       useAsTemplate();

--- a/src/scss/todoContext.scss
+++ b/src/scss/todoContext.scss
@@ -23,5 +23,20 @@
   }
   .card-content {
     padding: 0;
+    .horizontal {
+      display: flex;
+      text-align: center;
+      a.dropdown-item {
+        border-radius: 0;
+      }
+      a.dropdown-item:first-child {
+        border-top-left-radius: $radius;
+        border-top-right-radius: 0;
+      }
+      a.dropdown-item:last-child {
+        border-top-left-radius: 0;
+        border-top-right-radius: $radius;
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently, changing the priority of a todo entry takes a lot of clicks (when not using the keyboard).

This is a feature suggestion to add two very simple options to the todo context menu:
![sleek_prio_change_contextmenu](https://user-images.githubusercontent.com/1408105/160252153-4663b3e1-3565-4be5-8e96-74761176b962.png)


The arrow-up button will increase the todo priority by one, arrow-down will decrease it by one.

#### Notes / Discussion

- the new buttons are intentionally hidden for todo entries that don't have a priority assigned to them
    - I'm wondering if adding a "Set priority to A" to those would help getting non-prioritized quickly enlisted into the priorities and subsequently using the arrow-down function to lower them as necessary
- clicking arrow-up on a prio:A entry will simply do nothing (same with arrow-down for prio:Z)
    - I think it would be even better if we could grey out the options not applicable to those and make them non-clickable instead
