### PR TITLE
Improve Esc key behavior on search bar

### DIFF
--- a/src/js/keyboard.mjs
+++ b/src/js/keyboard.mjs
@@ -58,7 +58,16 @@ export async function registerShortcuts() {
       if(event.key === "Escape") {
 
         // if search is focused, lose focus on escape
-        if(document.activeElement.id==="todoTableSearch") todoTableSearch.blur();
+        if(document.activeElement.id==="todoTableSearch") {
+          todoTableSearch.blur();
+          return false;
+        }
+        // if 'add as todo' is focused, return to search
+        if(document.activeElement.id==="todoTableSearchAddTodo") {
+          document.getElementById("todoTableSearch").focus();
+          return false;
+        }
+
 
         // if a datepicker container is detected interrupt, datepicker destruction is handled in module
         if(document.querySelector(".datepicker")) return false;


### PR DESCRIPTION
This implements the following improvements for Esc key behavior on some elements of the search bar:

### Search bar

Goal: don't close filter drawer when pressing Esc in the search bar, just unfocus the search bar.

Use case intention: ability to quickly abort the search (e.g. to use global keybindings again such as "N" for a new todo) without affecting the filter drawer.

#### Old behavior

1. filter drawer open + search bar focused
2. Esc key pressed
3. filter drawer closed, search bar unfocused

#### New behavior

1. filter drawer open + search bar focused
2. Esc key pressed
3. search bar unfocused, filter drawer *stays* open

---

### "Add as todo" button

Goal: don't close filter drawer on Esc when "Add as todo" is focused, also return focus to search bar on Esc key press.

Use case intention: quicker way to decide against "Add as todo" while highlighted without affecting the filter drawer as an alternative to Shift+Tab.

#### Old behavior

1. filter drawer open + search bar focused
2. Tab key pressed
3. "Add as todo" focused
4. Esc key pressed
5. filter drawer closed, "Add as todo" *stays* focused

#### New behavior

1. filter drawer open + search bar focused
2. Tab key pressed
3. "Add as todo" focused
4. Esc key pressed
5. Focus shifted from "Add as todo" back to search bar, filter drawer *stays* open