### PR TITLE
Fix fallback for unrecognized translation codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sleek",
   "productName": "sleek",
-  "version": "1.2.2-rc.1",
+  "version": "1.2.2-rc.3",
   "description": "todo.txt manager for Linux, Windows and MacOS, free and open-source (FOSS)",
   "synopsis": "todo.txt manager for Linux, Windows and MacOS, free and open-source (FOSS)",
   "category": "ProjectManagement",

--- a/src/main.js
+++ b/src/main.js
@@ -423,8 +423,15 @@ function configureWindowEvents() {
     });
 
     ipcMain.handle("translations", async () => {
-      translations = await i18next.getDataByLanguage(userData.data.language).translation
-      return translations
+      translations = await i18next.getDataByLanguage(userData.data.language)
+
+      if(!translations) {
+        await i18next.changeLanguage(i18next.options.fallbackLng[0], function() {
+          return translations = i18next.getDataByLanguage(i18next.language)
+        })
+      }
+
+      return translations.translation
     });
 
     ipcMain.handle("getContent", async (event, file) => {


### PR DESCRIPTION
In an attempt to decide to help contribute to sleek, I caught up on issue https://github.com/ransome1/sleek/issues/358. I've got a couple years of JavaScript experience, this did not seem like a hard task to accomplish.

As mentioned in the issue, i18next does not seem to use the fallbackLng. This is due to that sleek uses the `getDataByLanguage` function instead of the more top-level function (such as changeLanguage).

I might take on more issues, depending on my availability. Let's first see how this fix lands.


TLDR: I've made a simple if-statement to check if the translation actually exists. If not, we load the default that was set as fallback.

Known issues:
- If you have an unknown language code set in your config file (in the case of the issue, it would be 'ko'), the dropdown in sleek's settings is defaulted to the first option (as none of the options has language code 'ko'. In my opinion this is intended. After all, even though we use the default language now, there is no 'correct' value set. So why should we show that here?