### PR TITLE
Fix for issue #311

### DIFF
--- a/src/js/filterlang.pegjs
+++ b/src/js/filterlang.pegjs
@@ -64,14 +64,14 @@ priorityKeyword
     = "pri" ("o" ("r" ("i" ("t" "y"?)?)?)?)?
 
 dueComparison
-    = "due" _ op:compareOp _ right:dateExpr  { return ["due"].concat(right, [op]); }
-    / "due:" right:dateStr  { return ["duestr", right]; }
-    / "due"  { return ["due"]; }
+    = "due:" _ op:compareOp _ right:dateExpr  { return ["due"].concat(right, [op]); }
+    / "due:" right:dateStr  { return ["duestr", right]; }  // this does string prefix match
+    / "due:"  { return ["due"]; }  // this tests for the presence of any due date
 
 thresholdComparison
-    = "t" _ op:compareOp _ right:dateExpr  { return ["threshold"].concat(right, [op]); }
-    / "t:" right:dateStr  { return ["tstr", right]; }
-    / "t"  { return ["threshold"]; }
+    = "t:" _ op:compareOp _ right:dateExpr  { return ["threshold"].concat(right, [op]); }
+    / "t:" right:dateStr  { return ["tstr", right]; }  // this does string prefix match
+    / "t:"  { return ["threshold"]; }  // this tests for the presence of any due date
 
 dateExpr
     = left:dateLiteral _ op:dateOp _ count:number unit:[dbwmy]  {

--- a/src/js/todos.mjs
+++ b/src/js/todos.mjs
@@ -693,11 +693,11 @@ async function createTodoContext(todoTableRow) {
     }
     // click on delete
     todoContextDelete.onclick = function() {
-      deleteTodo();
+      deleteTodo(index);
     }
     todoContextDelete.onkeypress = function(event) {
       if(event.key !== "Enter") return false;
-      deleteTodo();
+      deleteTodo(index);
     }
 
     todoContext.classList.add("is-active");


### PR DESCRIPTION
This is a change to the filter query language to address issue #311 .  The change is to use "due:" and "t:" as keywords rather than just "due" and "t".  NOTE: this is NOT BACKWARD COMPATIBLE, so people who use the query language will have to change the queries that they type.  We don't store those queries yet, so this is just a matter of remembering to add the colons when you type in new queries.

For example:

old query `due > tomorrow+3d` becomes new query `due: > tomorrow+3d`

old query `t <= 2022-11-01` becomes `t: <= 2022-11-01`

We should amend the filter query documentation to reflect this change.