### PR TITLE
Create done.txt for completed tasks

### DIFF
--- a/src/js/helper.mjs
+++ b/src/js/helper.mjs
@@ -165,11 +165,8 @@ export function getActiveFile() {
 }
 export function getDoneFile() {
   const activeFile = getActiveFile();
-  if(appData.os==="windows") {
-    return activeFile.replace(activeFile.split("\\").pop(), activeFile.substr(0, activeFile.lastIndexOf(".")).split("\\").pop() + "_done.txt");
-  } else {
-    return activeFile.replace(activeFile.split("/").pop(), activeFile.substr(0, activeFile.lastIndexOf(".")).split("/").pop() + "_done.txt");
-  }
+  var pathSeperator = (appData.os==="windows") ? "\\" : "/";
+  return activeFile.substr(0, activeFile.lastIndexOf(pathSeperator)) + pathSeperator +  "done.txt";
 }
 export function getBadgeCount() {
   let count = 0;

--- a/src/js/todos.mjs
+++ b/src/js/todos.mjs
@@ -879,7 +879,7 @@ async function archiveTodos() {
     let incompleteTodos = await items.objects.filter(function(item) { return item.complete === false });
 
     // if user archives within done.txt file, operating is canceled
-    if(activeFile.includes("_done.")) return Promise.resolve("Info: Current file seems to be a done.txt file, won't archive")
+    if(activeFile.endsWith("done.txt")) return Promise.resolve("Info: Current file seems to be a done.txt file, won't archive")
   
     let contentFromDoneFile = await window.api.invoke("getContent", doneFile);
 


### PR DESCRIPTION
Right now, when we hit Archive, the popup message says that a new file named `done.txt` will be created. But the actual file name ends up being `todo_done.txt`. 
Also, there is a bug with the existing file construction because of which the done file never gets created if filename matches any path of the folder structure. (Discussed in https://github.com/ransome1/sleek/issues/378). 

This will resolve both by creating `done.txt` in the same folder. 