### PR TITLE
Update Electron to a not EOL version

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,8 +153,8 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "electron": "18.3.7",
-    "electron-builder": "23.0.2",
+    "electron": "23.2.2",
+    "electron-builder": "23.3.2",
     "electron-notarize": "^1.2.2",
     "electron-reloader": "^1.2.2",
     "eslint": "^8.6.0"


### PR DESCRIPTION
Electron 18 is end of life so if feasable for this project, a newer Electron version should be used.

Should the Electron versions be with a `^` at the start like the other dependencies so that any electron version from that major version can be used?

Also, what is `electron-builder.yaml` even for if `electron-builder` uses what's specified in the `package.json` anyway?