### PR TITLE
Fixes adding all file extensions on linux

### DIFF
--- a/src/main/modules/FileDialog.ts
+++ b/src/main/modules/FileDialog.ts
@@ -6,8 +6,7 @@ import { configStorage } from '../config';
 
 async function openFile(): Promise<void> {
   try {
-    if (true) { //configStorage.get('allowAllFileExtensions')
-    // const allowedFileExtensions = (configStorage.get('allowAllFileExtensions')) ? ['*'] : ['txt', 'md']
+    if (configStorage.get('allowAllFileExtensions')) {
     const result: OpenDialogReturnValue = await dialog.showOpenDialog({
       properties: ['openFile'],
       filters: [
@@ -17,7 +16,7 @@ async function openFile(): Promise<void> {
         },
         {
           name: 'Text Files',
-          extensions: ['txt', 'md'] 
+          extensions: ['txt', 'md', 'todotxt'] 
         }],
         });
       
@@ -26,7 +25,7 @@ async function openFile(): Promise<void> {
           properties: ['openFile'],
           filters: [{ 
             name: 'Text Files',
-            extensions: ['txt', 'md'] }],
+            extensions: ['txt', 'md', 'todotxt'] }],
           });
     }
     if (!result.canceled && result.filePaths.length > 0) {

--- a/src/main/modules/FileDialog.ts
+++ b/src/main/modules/FileDialog.ts
@@ -6,14 +6,29 @@ import { configStorage } from '../config';
 
 async function openFile(): Promise<void> {
   try {
-    const allowedFileExtensions = (configStorage.get('allowAllFileExtensions')) ? [] : ['txt', 'md']
+    if (true) { //configStorage.get('allowAllFileExtensions')
+    // const allowedFileExtensions = (configStorage.get('allowAllFileExtensions')) ? ['*'] : ['txt', 'md']
     const result: OpenDialogReturnValue = await dialog.showOpenDialog({
       properties: ['openFile'],
-      filters: [{ 
-        name: 'Text Files',
-        extensions: allowedFileExtensions }],
-    });
-
+      filters: [
+        { 
+          name: 'All Files',
+          extensions: ['*']
+        },
+        {
+          name: 'Text Files',
+          extensions: ['txt', 'md'] 
+        }],
+        });
+      
+    } else {
+      const result: OpenDialogReturnValue = await dialog.showOpenDialog({
+          properties: ['openFile'],
+          filters: [{ 
+            name: 'Text Files',
+            extensions: ['txt', 'md'] }],
+          });
+    }
     if (!result.canceled && result.filePaths.length > 0) {
       const filePath: string = result.filePaths[0];
       addFile(filePath);


### PR DESCRIPTION
I have preserved the variable to enable all file selection.  I think it should be removed. 
also added .todotxt files that obsidian uses as default Text files.  

I don't know if I have done it correctly but it works on my machine. 

This contributes to #514