### PR TITLE
Fix ransome1/sleek#543

### DIFF
--- a/src/__tests__/main/CreateRecurringTodo.tsx
+++ b/src/__tests__/main/CreateRecurringTodo.tsx
@@ -91,5 +91,11 @@ describe('Create recurring todos', () => {
     const fileContent = await fs.readFile('./src/__tests__/__mock__/recurrence.txt', 'utf8');
     expect(fileContent.split('\n').pop()).toEqual(`${dateTodayString} Line 1 rec:+1d t:2023-09-20 due:${dateTomorrowString}`);
   });  
-  
+
+  test('Should add a new todo and set the priority to the value of the pri extension', async () => {
+    const recurringTodo = await createRecurringTodo(`x ${dateTodayString} ${dateTodayString} Line 1 rec:1d pri:A`, '1d');
+    const fileContent = await fs.readFile('./src/__tests__/__mock__/recurrence.txt', 'utf8');
+    expect(fileContent.split('\n').pop()).toEqual(`(A) ${dateTodayString} Line 1 rec:1d due:${dateTomorrowString} pri:A`);
+  });
+
 });

--- a/src/main/modules/TodoObject/CreateRecurringTodo.tsx
+++ b/src/main/modules/TodoObject/CreateRecurringTodo.tsx
@@ -52,6 +52,12 @@ const createRecurringTodo = async (string: string, recurrence: string): Promise<
       recurringTodoObject.setCreated(null);
     }
 
+    const previousPriorityIndex = recurringTodoObject.extensions().findIndex((extension) => extension.key === 'pri');
+    const previousPriorityString = recurringTodoObject.extensions()[previousPriorityIndex]?.value;
+    if(previousPriorityString && previousPriorityString !== 'null') {
+      recurringTodoObject.setPriority(previousPriorityString)
+    }
+
     if (recurrence && completedDate) {
       const strictRecurrence: boolean = recurrence.startsWith('+');
       const recurrenceInterval: any = strictRecurrence ? recurrence.slice(1) : recurrence;


### PR DESCRIPTION
Recover the task priority from the pri: extension the same way as is done for un-completing tasks.

Unfortunately I don't have a build environment so I can't verify the test before pushing this PR - it's visibly correct though.