### PR TITLE
Fixes priority and recurrence.

### DIFF
--- a/src/__tests__/main/CreateRecurringTodo.tsx
+++ b/src/__tests__/main/CreateRecurringTodo.tsx
@@ -86,16 +86,22 @@ describe('Create recurring todos', () => {
     expect(fileContent.split('\n').pop()).toEqual(`${dateTodayString} Water plants @home +quick due:${dateInOneWeekString} t:${dateInOneWeekMinus10String} rec:1w`);
   });
 
-  test('Should add a new todo adding a strict recurrence of one day to due date and threshold date, while the todo initially only has a threshold date', async () => {
+  test('Should add a new todo adding a strict recurrence of one day to threshold date. No due date should be created.', async () => {
     const recurringTodo = await createRecurringTodo(`x ${dateTodayString} ${dateTodayString} Line 1 rec:+1d t:2023-09-19`, '1+d');
     const fileContent = await fs.readFile('./src/__tests__/__mock__/recurrence.txt', 'utf8');
-    expect(fileContent.split('\n').pop()).toEqual(`${dateTodayString} Line 1 rec:+1d t:2023-09-20 due:${dateTomorrowString}`);
+    expect(fileContent.split('\n').pop()).toEqual(`${dateTodayString} Line 1 rec:+1d t:2023-09-20`);
   });  
 
-  test('Should add a new todo and set the priority to the value of the pri extension', async () => {
+  test('Should add a new todo and preserve the priority in the pri extension, but should not set the priority (A) for the task.', async () => {
     const recurringTodo = await createRecurringTodo(`x ${dateTodayString} ${dateTodayString} Line 1 rec:1d pri:A`, '1d');
     const fileContent = await fs.readFile('./src/__tests__/__mock__/recurrence.txt', 'utf8');
-    expect(fileContent.split('\n').pop()).toEqual(`(A) ${dateTodayString} Line 1 rec:1d pri:A due:${dateTomorrowString}`);
+    expect(fileContent.split('\n').pop()).toEqual(`${dateTodayString} Line 1 rec:1d pri:A due:${dateTomorrowString}`);
+  });
+
+  test('Should add a new todo based on a daily recurrence and a threshold date set for today, without unwanted due date and priority labels', async () => {
+    const recurringTodo = await createRecurringTodo(`x ${dateTodayString} ${dateTodayString} (A) Do something rec:d t:${dateTodayString} @SomeContext`, 'd');
+    const fileContent = await fs.readFile('./src/__tests__/__mock__/recurrence.txt', 'utf8');
+    expect(fileContent.split('\n').pop()).toEqual(`${dateTodayString} (A) Do something rec:d t:${dateTomorrowString} @SomeContext`);
   });
 
 });

--- a/src/main/modules/TodoObject/ChangeCompleteState.tsx
+++ b/src/main/modules/TodoObject/ChangeCompleteState.tsx
@@ -10,6 +10,16 @@ async function changeCompleteState(todoString: string, state: boolean): Promise<
     JsTodoTxtObject.setCreated(JsTodoTxtObject.created() ? JsTodoTxtObject.created() : new Date());
     JsTodoTxtObject.setCompleted(new Date());
 
+    const recurrence = JsTodoTxtObject?.extensions().find((item) => item.key === 'rec');
+    if (recurrence?.value) {
+      try {
+        const response = await createRecurringTodo(JsTodoTxtObject.toString(), recurrence.value);
+        console.log('changeCompleteState.ts:', response);
+      } catch (error: any) {
+        console.error(error);
+      }
+    }
+
     const currentPriority = JsTodoTxtObject.priority();
     if(currentPriority) {
       JsTodoTxtObject.setPriority(null)
@@ -19,16 +29,6 @@ async function changeCompleteState(todoString: string, state: boolean): Promise<
   } else {
     JsTodoTxtObject.setCompleted(null);
     restorePreviousPriority(JsTodoTxtObject);
-  }
-
-  const recurrence = JsTodoTxtObject?.extensions().find((item) => item.key === 'rec');
-  if (state && recurrence?.value) {
-    try {
-      const response = await createRecurringTodo(JsTodoTxtObject.toString(), recurrence.value);
-      console.log('changeCompleteState.ts:', response);
-    } catch (error: any) {
-      console.error(error);
-    }
   }
 
   const updatedTodoString = JsTodoTxtObject.toString();

--- a/src/main/modules/TodoObject/CreateRecurringTodo.tsx
+++ b/src/main/modules/TodoObject/CreateRecurringTodo.tsx
@@ -1,7 +1,6 @@
 import { Item } from 'jstodotxt';
 import dayjs from 'dayjs';
 import { writeTodoObjectToFile } from '../File/Write';
-import restorePreviousPriority from './RestorePreviousPriority';
 import { configStorage } from '../../config';
 
 enum RecurrenceInterval {
@@ -53,8 +52,6 @@ const createRecurringTodo = async (string: string, recurrence: string): Promise<
       JsTodoTxtObject.setCreated(null);
     }
 
-    restorePreviousPriority(JsTodoTxtObject);
-
     if (recurrence && completedDate) {
       const strictRecurrence: boolean = recurrence.startsWith('+');
       const recurrenceInterval: any = strictRecurrence ? recurrence.slice(1) : recurrence;
@@ -67,7 +64,10 @@ const createRecurringTodo = async (string: string, recurrence: string): Promise<
       const newThresholdDate = strictRecurrence
         ? addRecurrenceToDate(dayjs(oldThresholdDate).toDate(), recurrenceInterval)
         : dayjs(newDueDate).subtract(daysBetween, 'day').toDate();
-      if(completedDate) JsTodoTxtObject.setExtension('due', dayjs(newDueDate).format('YYYY-MM-DD'));
+
+      // If the user only uses threshold date and no due date, the recurrence should not create a due date:
+      const recurrenceOnlyForThresholdDate = oldThresholdDate && !oldDueDate;
+      if(completedDate && !recurrenceOnlyForThresholdDate) JsTodoTxtObject.setExtension('due', dayjs(newDueDate).format('YYYY-MM-DD'));
       if(oldThresholdDate) JsTodoTxtObject.setExtension('t', dayjs(newThresholdDate).format('YYYY-MM-DD'));
       JsTodoTxtObject.setComplete(false);
       JsTodoTxtObject.setCompleted(null);


### PR DESCRIPTION
This PR fixes #565.

- If a task with threshold date and no due date is completed, only the threshold date gets bumped by the recurrence. No extra due date is added.
- Tasks created by recurrence no longer have the `pri:` attribute added. Only the completed tasks have the `pri:` attribute.
- If a task does not have a priority `(A-Z)` before completion and only a key value pair `pri:a-z`, then the newly created recurrence task follows the same convention.