### PR TITLE
projects/contexts list length, addresses ransome1/sleek#616

### DIFF
--- a/src/main/modules/Filters/FilterQuery.js
+++ b/src/main/modules/Filters/FilterQuery.js
@@ -110,7 +110,7 @@ function runQuery(todoObject, compiledQuery) {
       case "++":
         next = q.shift();
         if(next === "*") {
-          stack.push(todoObject.projects ? true : false);
+          stack.push(todoObject.projects.length > 0);
         } else if(next.startsWith('"')) {
           stack.push(todoObject.projects && todoObject.projects.includes(next.slice(1,-1)));
         } else {
@@ -124,7 +124,7 @@ function runQuery(todoObject, compiledQuery) {
       case "@@":
         next = q.shift();
         if(next === "*") {
-          stack.push(todoObject.contexts ? true : false);
+          stack.push(todoObject.contexts.length > 0);
         } else if(next.startsWith('"')) {
           stack.push(todoObject.contexts && todoObject.contexts.includes(next.slice(1,-1)));
         } else {


### PR DESCRIPTION
This code change to FilterQuery.js will address the problem described in issue #616.  The old code worked with the todoObject as it behaved in version 1.2.9 of sleek, but fails in 2.0.6.  I think that the old version must have represented missing projects or contexts as undefined or nil, while the new version represents this case as an empty list.   This PR adds an explicit check of the length of the lists.