### PR TITLE
solves filter bug due to todoObject.toString, issue #647

### DIFF
--- a/src/main/modules/Filters/FilterQuery.js
+++ b/src/main/modules/Filters/FilterQuery.js
@@ -71,11 +71,11 @@ function runQuery(todoObject, compiledQuery) {
         break;
       case "string":
         next = q.shift();  // the string value to match
-        stack.push(todoObject.toString().toLowerCase().indexOf(next.toLowerCase()) !== -1);
+        stack.push(todoObject.string.toLowerCase().indexOf(next.toLowerCase()) !== -1);
         break;
       case "regex":
         next = q.shift();  // the regex to match
-        stack.push(next.test(todoObject.toString()));
+        stack.push(next.test(todoObject.string));
         break;
       case "==":
         operand2 = stack.pop();


### PR DESCRIPTION
This functionality was broken in sleek v2 when the `todoObject.toString()` method stopped doing what it did in v1.  The fix is to replace `todoObject.toString()` with `todoObject.string`.
