### PR TITLE
WIP: When friendly dates are enabled, group elements use friendly dates

### DIFF
--- a/src/main/modules/Attributes.tsx
+++ b/src/main/modules/Attributes.tsx
@@ -22,7 +22,9 @@ function incrementCount(countObject: any, key: any | null, notify: boolean): voi
 
 function updateAttributes(todoObjects: TodoObject[], sorting: Sorting[], reset: boolean) {
 
-  for (const key in attributes) {
+  const attributeKeys = Object.keys(attributes) as AttributeKey[];
+
+  for (const key of attributeKeys) {
 
     for (const attributeKey in attributes[key]) {
       (reset) ? attributes[key] = {} : attributes[key][attributeKey].count = 0

--- a/src/main/modules/Attributes.tsx
+++ b/src/main/modules/Attributes.tsx
@@ -10,6 +10,15 @@ const attributes: Attributes = {
   completed: {} as DateAttribute,
 };
 
+function getDateAttributes(): DateAttributes {
+  return {
+    due: attributes.due,
+    t: attributes.t,
+    created: attributes.created,
+    completed: attributes.completed,
+  };
+}
+
 function incrementCount(countObject: any, key: any | null, notify: boolean): void {
   if(key) {
     let previousCount: number = parseInt(countObject[key]?.count) || 0;
@@ -52,4 +61,4 @@ function updateAttributes(todoObjects: TodoObject[], sorting: Sorting[], reset: 
   }
 }
 
-export { attributes, updateAttributes };
+export { attributes, getDateAttributes, updateAttributes };

--- a/src/main/modules/Attributes.tsx
+++ b/src/main/modules/Attributes.tsx
@@ -48,7 +48,6 @@ function updateAttributes(todoObjects: TodoObject[], sorting: Sorting[], reset: 
     }
     attributes[key] = Object.fromEntries(Object.entries(attributes[key]).sort(([a], [b]) => a.localeCompare(b)));
   }
-  attributes = Object.fromEntries(sorting.map((item) => [item.value, attributes[item.value]]));
 }
 
 export { attributes, updateAttributes };

--- a/src/main/modules/Attributes.tsx
+++ b/src/main/modules/Attributes.tsx
@@ -2,12 +2,12 @@ const attributes: Attributes = {
   priority: {},
   projects: {},
   contexts: {},
-  due: {},
-  t: {},
+  due: {} as DateAttribute,
+  t: {} as DateAttribute,
   rec: {},
   pm: {},
-  created: {},
-  completed: {},
+  created: {} as DateAttribute,
+  completed: {} as DateAttribute,
 };
 
 function incrementCount(countObject: any, key: any | null, notify: boolean): void {

--- a/src/main/modules/Attributes.tsx
+++ b/src/main/modules/Attributes.tsx
@@ -1,4 +1,4 @@
-let attributes: Attributes = {
+const attributes: Attributes = {
   priority: {},
   projects: {},
   contexts: {},

--- a/src/main/modules/Attributes.tsx
+++ b/src/main/modules/Attributes.tsx
@@ -21,33 +21,33 @@ function incrementCount(countObject: any, key: any | null, notify: boolean): voi
 }
 
 function updateAttributes(todoObjects: TodoObject[], sorting: Sorting[], reset: boolean) {
-  
-  Object.keys(attributes).forEach((key) => {
-    
-    Object.keys(attributes[key]).forEach((attributeKey) => {
-      (reset) ? attributes[key] = {} : attributes[key][attributeKey].count = 0
-    });
 
-    todoObjects.forEach((todoObject: TodoObject) => {
+  for (const key in attributes) {
+
+    for (const attributeKey in attributes[key]) {
+      (reset) ? attributes[key] = {} : attributes[key][attributeKey].count = 0
+    };
+
+    for (const todoObject of todoObjects) {
       const value = todoObject[key as keyof TodoObject];
       const notify: boolean = (key === 'due') ? !!todoObject?.notify : false;
-      
+
       if(Array.isArray(value)) {
-        value.forEach((element) => {
+        for (const element of value) {
           if(element !== null) {
             const attributeKey = element as keyof Attribute;
-            
+
             incrementCount(attributes[key], attributeKey, notify);
           }
-        });
+        }
       } else {
         if(value !== null) {
           incrementCount(attributes[key], value, notify);
         }
       }
-    });
+    }
     attributes[key] = Object.fromEntries(Object.entries(attributes[key]).sort(([a], [b]) => a.localeCompare(b)));
-  });
+  }
   attributes = Object.fromEntries(sorting.map((item) => [item.value, attributes[item.value]]));
 }
 

--- a/src/main/modules/DataRequest/CreateTodoObjects.tsx
+++ b/src/main/modules/DataRequest/CreateTodoObjects.tsx
@@ -31,12 +31,12 @@ function createTodoObject(lineNumber: number, string: string, attributeType?: st
   content = JsTodoTxtObject.toString().replaceAll(' [LB] ', String.fromCharCode(16));
 
   const body = JsTodoTxtObject.body().replaceAll(' [LB] ', ' ');
-  const speakingDates: DateAttributes = extractSpeakingDates(body);
-  const due = speakingDates['due:']?.date || null;
-  const dueString = speakingDates['due:']?.string || null;
-  const notify = speakingDates['due:']?.notify || false;
-  const t = speakingDates['t:']?.date || null;
-  const tString = speakingDates['t:']?.string || null;
+  const speakingDates = extractSpeakingDates(body);
+  const due = speakingDates.due?.date || null;
+  const dueString = speakingDates.due?.string || null;
+  const notify = speakingDates.due?.notify || false;
+  const t = speakingDates.t?.date || null;
+  const tString = speakingDates.t?.string || null;
   const hidden = extensions.some(extension => extension.key === 'h' && extension.value === '1');
   const pm: string | number | null = extensions.find(extension => extension.key === 'pm')?.value || null;
   const rec = extensions.find(extension => extension.key === 'rec')?.value || null;

--- a/src/main/modules/DataRequest/SortAndGroup.tsx
+++ b/src/main/modules/DataRequest/SortAndGroup.tsx
@@ -1,4 +1,6 @@
 import { config } from '../../config';
+import { getDateAttributes } from '../Attributes';
+import { friendlyDateGroup } from '../Date';
 
 function sortAndGroupTodoObjects(todoObjects: TodoObject[], sorting: Sorting[]): TodoGroup {
   const fileSorting: boolean = config.get('fileSorting');
@@ -31,13 +33,24 @@ function sortAndGroupTodoObjects(todoObjects: TodoObject[], sorting: Sorting[]):
     return 0;
   }
 
+  function getGroupKey(todoObject: TodoObject, attributeKey: string) {
+    const useFriendlyDates = config.get('useHumanFriendlyDates');
+    const isDateAttribute = Object.keys(getDateAttributes()).includes(attributeKey);
+
+    if (useFriendlyDates && isDateAttribute) {
+      return friendlyDateGroup(todoObject[attributeKey]);
+    }
+
+    return todoObject[attributeKey];
+  }
+
   function groupTodoObjectsByKey(todoObjects: TodoObject[], attributeKey: string) {
     const grouped: TodoGroup = {};
     for (const todoObject of todoObjects) {
-      const groupKey = todoObject[attributeKey] || null;
+      const groupKey = getGroupKey(todoObject, attributeKey);
       if (!grouped[groupKey]) {
         grouped[groupKey] = {
-          title: groupKey,
+          title: todoObject[attributeKey],
           todoObjects: [],
           visible: false
         };

--- a/src/main/modules/Date.tsx
+++ b/src/main/modules/Date.tsx
@@ -1,5 +1,5 @@
 import Sugar from 'sugar';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import { config } from '../config';
 
 function mustNotify(date: Date): boolean {
@@ -86,4 +86,54 @@ function extractSpeakingDates(body: string): DateAttributes {
   return speakingDates;
 }
 
-export { extractSpeakingDates, replaceSpeakingDatesWithAbsoluteDates };
+function friendlyDateGroup(date: Dayjs): FriendlyDateGroup | null {
+  const today = dayjs();
+
+  if (!date || !date.isValid()) {
+    return null;
+  }
+
+  if (date.isBefore(today.subtract(1, 'week'))) {
+    return 'before-last-week';
+  }
+
+  if (date.isBefore(today.subtract(1, 'day'))) {
+    return 'last-week';
+  }
+
+  if (date.isBefore(today)) {
+    return 'yesterday';
+  }
+
+  if (date.isSame(today)) {
+    return 'today';
+  }
+
+  if (date.isSame(today.add(1, 'day'))) {
+    return 'tomorrow';
+  }
+
+  if (date.isBefore(today.add(1, 'week').add(1, 'day'))) {
+    return 'this-week';
+  }
+
+  if (date.isBefore(today.add(2, 'week').add(1, 'day'))) {
+    return 'next-week';
+  }
+
+  if (date.isBefore(today.add(1, 'month').add(1, 'day'))) {
+    return 'this-month';
+  }
+
+  if (date.isBefore(today.add(2, 'month').add(1, 'day'))) {
+    return 'next-month';
+  }
+
+  return 'after-next-month';
+}
+
+export {
+  extractSpeakingDates,
+  friendlyDateGroup,
+  replaceSpeakingDatesWithAbsoluteDates
+};

--- a/src/main/modules/Date.tsx
+++ b/src/main/modules/Date.tsx
@@ -9,9 +9,9 @@ function mustNotify(date: Date): boolean {
 }
 
 function replaceSpeakingDatesWithAbsoluteDates(string: string): string {
-  const speakingDates: DateAttributes = extractSpeakingDates(string);
-  const due: DateAttribute = speakingDates['due:'];
-  const t: DateAttribute = speakingDates['t:'];
+  const speakingDates = extractSpeakingDates(string);
+  const due: DateAttribute = speakingDates.due;
+  const t: DateAttribute = speakingDates.t;
   if(due.date) {
     string = string.replace(due.string!, due.date);
   }
@@ -50,22 +50,22 @@ function processDateWithSugar(string: string, type: string): DateAttribute | nul
   return lastMatch;
 }
 
-function extractSpeakingDates(body: string): DateAttributes {
-  const expressions = [
-    { pattern: /due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=t:|$)/g, key: 'due:', type: 'relative' },
-    { pattern: /due:(\d{4}-\d{2}-\d{2})/g, key: 'due:', type: 'absolute' },
-    { pattern: /t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=due:|$)/g, key: 't:', type: 'relative' },
-    { pattern: /t:(\d{4}-\d{2}-\d{2})/g, key: 't:', type: 'absolute' },
+function extractSpeakingDates(body: string): Pick<DateAttributes, 'due'|'t'> {
+  const expressions: { pattern: RegExp, key: 'due'|'t', type: string }[] = [
+    { pattern: /due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=t:|$)/g, key: 'due', type: 'relative' },
+    { pattern: /due:(\d{4}-\d{2}-\d{2})/g, key: 'due', type: 'absolute' },
+    { pattern: /t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=due:|$)/g, key: 't', type: 'relative' },
+    { pattern: /t:(\d{4}-\d{2}-\d{2})/g, key: 't', type: 'absolute' },
   ];
 
-  const speakingDates: DateAttributes = {
-    'due:': {
+  const speakingDates: Pick<DateAttributes, 'due'|'t'> = {
+    'due': {
       date: null,
       string: null,
       type: null,
       notify: false,
     },
-    't:': {
+    't': {
       date: null,
       string: null,
       type: null,

--- a/src/renderer/Grid/Grid.tsx
+++ b/src/renderer/Grid/Grid.tsx
@@ -100,6 +100,7 @@ const GridComponent: React.FC<GridComponentProps> = memo(({
         return (
           <React.Fragment key={group.title}>
             <Group
+              settings={settings}
               title={group.title}
               todotxtAttribute={settings.sorting[0].value}
               filters={filters}

--- a/src/renderer/Grid/Group.tsx
+++ b/src/renderer/Grid/Group.tsx
@@ -2,25 +2,58 @@ import React, { memo } from 'react';
 import ListItem from '@mui/material/ListItem';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import dayjs from 'dayjs';
+import updateLocale from 'dayjs/plugin/updateLocale';
+import { friendlyDate } from 'renderer/Shared';
+import type { i18n } from 'renderer/Settings/LanguageSelector';
+import { type WithTranslation, withTranslation } from 'react-i18next';
+import { getDateAttributes } from 'main/modules/Attributes';
+dayjs.extend(updateLocale);
 
-interface GroupProps {
+interface FormatGroupElementProps {
+  groupElement: string;
+  settings: Settings;
+  t: typeof i18n.t;
+  todotxtAttribute: string;
+}
+
+function formatGroupElement({ groupElement, settings, t, todotxtAttribute }: FormatGroupElementProps) {
+  // If group element is a date, then format according to user preferences
+  const dateAttributeKeys = Object.keys(getDateAttributes());
+  if (
+    dateAttributeKeys.includes(todotxtAttribute)
+      && dayjs(groupElement).isValid()
+      && settings.useHumanFriendlyDates
+  ) {
+    return friendlyDate(groupElement, todotxtAttribute, t).pop();
+  }
+
+  // No transformation required: display as-is
+  return groupElement;
+}
+
+interface GroupProps extends WithTranslation {
+  settings: Settings;
   title: string | string[];
   todotxtAttribute: string;
   filters: Filters | null;
   onClick: Function;
+  t: typeof i18n.t;
 }
 
-const Group: React.FC<GroupProps> = memo(({ title, todotxtAttribute, filters, onClick }) => {
-
+const Group: React.FC<GroupProps> = memo(({ settings, t, title, todotxtAttribute, filters, onClick }) => {
   if (!title || title.length === 0) {
     return <ListItem className="row group"><Divider /></ListItem>;
   }
   
   const groupElements = (typeof title === 'string') ? [title] : title
+  const formattedGroupElements = groupElements.map(
+    (groupElement) => formatGroupElement({ groupElement, settings, t, todotxtAttribute })
+  );
 
   return (
     <ListItem className="row group">
-      {groupElements.map((groupElement, index) => {
+      {formattedGroupElements.map((groupElement, index) => {
         const selected: boolean = filters && (filters[todotxtAttribute as keyof Filters] || []).some(
           (filter: Filter) => filter && filter.name === groupElement.trim()
         );
@@ -41,4 +74,4 @@ const Group: React.FC<GroupProps> = memo(({ title, todotxtAttribute, filters, on
   );
 });
 
-export default Group;
+export default withTranslation()(Group);

--- a/src/renderer/Shared.tsx
+++ b/src/renderer/Shared.tsx
@@ -4,6 +4,7 @@ import duration from 'dayjs/plugin/duration';
 import calendar from 'dayjs/plugin/calendar';
 import weekday from 'dayjs/plugin/weekday';
 import updateLocale from 'dayjs/plugin/updateLocale';
+import { i18n } from './Settings/LanguageSelector';
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
 dayjs.extend(calendar);

--- a/src/renderer/Shared.tsx
+++ b/src/renderer/Shared.tsx
@@ -5,6 +5,7 @@ import calendar from 'dayjs/plugin/calendar';
 import weekday from 'dayjs/plugin/weekday';
 import updateLocale from 'dayjs/plugin/updateLocale';
 import { i18n } from './Settings/LanguageSelector';
+import { friendlyDateGroup } from 'main/modules/Date';
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
 dayjs.extend(calendar);
@@ -68,48 +69,47 @@ export const friendlyDate = (value: string, attributeKey: string, settings: Sett
     weekStart: settings.weekStart,
   });
 
-  const today = dayjs();
   const date = dayjs(value);
+  const group = friendlyDateGroup(date);
+
   const results = [];
 
-  if (date.isBefore(today, 'day')) {
-    results.push((attributeKey === 'due') ? t('drawer.attributes.overdue') : t('drawer.attributes.elapsed'));
-  }  
-
-  if (date.isAfter(today.subtract(1, 'week').startOf('week').subtract(1, 'day')) && date.isBefore(today.subtract(1, 'week').endOf('week'))) {
-    results.push(t('drawer.attributes.lastWeek'));
-  }
-
-  if (date.isBefore(today.endOf('month')) && date.isAfter(today.subtract(1, 'day'), 'day')) {
-    results.push(t('drawer.attributes.thisMonth'));
-  }
-
-  if (date.isSame(today, 'week')) {
-    results.push(t('drawer.attributes.thisWeek'));
-  }  
-
-  if (date.isSame(today.subtract(1, 'day'), 'day')) {
-    results.push(t('drawer.attributes.yesterday'));
-  }
-
-  if (date.isSame(today, 'day')) {
-    results.push(t('drawer.attributes.today'));
-  }
-
-  if (date.isSame(today.add(1, 'day'), 'day')) {
-    results.push(t('drawer.attributes.tomorrow'));
-  }
-
-  if (date.isSame(today.add(1, 'week'), 'week')) {
-    results.push(t('drawer.attributes.nextWeek'));
-  }
-
-  if (date.month() === today.add(1, 'month').month()) {
-    results.push(t('drawer.attributes.nextMonth'));
-  }
-
-  if (date.isAfter(today.add(1, 'month').endOf('month'))) {
-    results.push(dayjs(date).format('YYYY-MM-DD'));
+  switch (group) {
+    case null:
+      // This should never happen, as `date` will always be a valid date
+      break;
+    case 'before-last-week':
+      results.push((attributeKey === 'due') ? t('drawer.attributes.overdue') : t('drawer.attributes.elapsed'));
+      break;
+    case 'last-week':
+      results.push((attributeKey === 'due') ? t('drawer.attributes.overdue') : t('drawer.attributes.elapsed'));
+      results.push(t('drawer.attributes.lastWeek'));
+      break;
+    case 'yesterday':
+      results.push((attributeKey === 'due') ? t('drawer.attributes.overdue') : t('drawer.attributes.elapsed'));
+      results.push(t('drawer.attributes.yesterday'));
+      break;
+    case 'today':
+      results.push(t('drawer.attributes.today'));
+      break;
+    case 'tomorrow':
+      results.push(t('drawer.attributes.tomorrow'));
+      break;
+    case 'this-week':
+      results.push(t('drawer.attributes.thisWeek'));
+      break;
+    case 'next-week':
+      results.push(t('drawer.attributes.nextWeek'));
+      break;
+    case 'this-month':
+      results.push(t('drawer.attributes.thisMonth'));
+      break;
+    case 'next-month':
+      results.push(t('drawer.attributes.nextMonth'));
+      break;
+    case 'after-next-month':
+      results.push(dayjs(date).format('YYYY-MM-DD'));
+      break;
   }
 
   return results;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -191,19 +191,13 @@ declare global {
   }
 
   type Attributes = {
-    [key in AttributeKey]: {
-      [key: string]: Attribute;
-    }
+    [attributeKey in AttributeKey]:
+      attributeKey extends DateAttributeKey
+        ? DateAttribute
+        : { [key: string]: Attribute; };
   }
 
-  type DateAttributes = {
-    [key: string]: {
-      date: string | null;
-      string: string | null;
-      type: string | null;
-      notify: boolean;
-    };
-  };
+  type DateAttributes = Pick<Attributes, DateAttributeKey>;
 
   type DateAttribute = {
     date: string | null;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -168,12 +168,30 @@ declare global {
     exclude: boolean;
   }
 
+  type AttributeKey =
+    'priority'
+    | 'projects'
+    | 'contexts'
+    | 'due'
+    | 't'
+    | 'rec'
+    | 'pm'
+    | 'created'
+    | 'completed';
+
+  type DateAttributeKey = AttributeKey & (
+    'due'
+    | 't'
+    | 'created'
+    | 'completed'
+  );
+
   interface Attribute {
     [key: string]: number | boolean;
   }
 
-  interface Attributes {
-    [key: string]: {
+  type Attributes = {
+    [key in AttributeKey]: {
       [key: string]: Attribute;
     }
   }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -247,6 +247,18 @@ declare global {
   };
 
   type VisibleSettings = Record<string, VisibleSetting>;
+
+  type FriendlyDateGroup =
+    | 'before-last-week'
+    | 'last-week'
+    | 'yesterday'
+    | 'today'
+    | 'tomorrow'
+    | 'this-week'
+    | 'next-week'
+    | 'this-month'
+    | 'next-month'
+    | 'after-next-month';
 }
 
 export {};


### PR DESCRIPTION
This PR is a WIP. I'm putting it up so that nobody duplicates effort. And @ransome1, feel free to let me know if this the intent of this PR is not what you want, and I'll stop working on it!

TODO:

- [X] Implement the feature
- [ ] Write tests
- [ ] Apply Prettier
- [ ] Check all documentation is up-to-date
- [ ] Tidy up the commit history

---

I love the 'friendly dates' feature. Right now, when you enable it in Settings, tags for due dates and threshold dates are displayed using localised, human-friendly words like 'today' and 'tomorrow' rather than ISO strings.

I would love it if this feature extended to 'group elements', ie the headings which appear above grouped todo items.

This PR does that. Now, when the user enables friendly dates in settings, those group elements use friendly dates. (If the user doesn't enable friendly dates in settings, nothing is different.)

![Screenshot of group elements showing friendly dates for due dates](https://github.com/ransome1/sleek/assets/118172583/3e895b69-e2a8-42ad-9e8d-4f76674b3cc0)
