### PR TITLE
fix: issue 781 - correct numerical values sorting logic (pomodoro)

### DIFF
--- a/src/main/DataRequest/Sort.ts
+++ b/src/main/DataRequest/Sort.ts
@@ -5,6 +5,13 @@ const compareValues = (a: any, b: any, invert: boolean): number => {
   if (a === null || a === undefined) return 1;
   if (b === null || b === undefined) return -1;
 
+  const numA = typeof a === 'string' && !isNaN(Number(a)) ? Number(a) : a;
+  const numB = typeof b === 'string' && !isNaN(Number(b)) ? Number(b) : b;
+
+  if (typeof numA === 'number' && typeof numB === 'number') {
+    return invert ? numB - numA : numA - numB;
+  }
+
   const strA = String(a);
   const strB = String(b);
 


### PR DESCRIPTION
I try to fix this issue:
Sorting Issue: "Tomatoes" Attribute Orders Alphabetically Instead of Numerically
[#781](https://github.com/ransome1/sleek/issues/781)