### PR TITLE
Fix speaking dates parsing with additional attrs

### DIFF
--- a/src/main/Date.ts
+++ b/src/main/Date.ts
@@ -1,6 +1,5 @@
 import Sugar from 'sugar'
 import { MustNotify } from './Notifications'
-import { SettingsStore } from '../Stores'
 
 export function replaceSpeakingDatesWithAbsoluteDates(string: string): string {
   const speakingDates: DateAttributes = extractSpeakingDates(string)
@@ -42,9 +41,9 @@ function processDateWithSugar(string: string, type: string) {
 
 export function extractSpeakingDates(body: string) {
   const expressions = [
-    { pattern: /due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=t:|$)/g, key: 'due:', type: 'relative' },
+    { pattern: /due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g, key: 'due:', type: 'relative' },
     { pattern: /due:(\d{4}-\d{2}-\d{2})/g, key: 'due:', type: 'absolute' },
-    { pattern: /t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=due:|$)/g, key: 't:', type: 'relative' },
+    { pattern: /t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g, key: 't:', type: 'relative' },
     { pattern: /t:(\d{4}-\d{2}-\d{2})/g, key: 't:', type: 'absolute' }
   ]
 


### PR DESCRIPTION
Tags written after a speaking date were falsely parsed as part of the speaking date. Only the threshold tag was excluded by this. With this change, any tag will be excluded correctly.

Fixes #728