### PR TITLE
Fix writing empty lines to done.txt

### DIFF
--- a/src/main/File/Archive.ts
+++ b/src/main/File/Archive.ts
@@ -62,8 +62,9 @@ function archiveTodos(): string {
     activeFile.doneFileBookmark
   )
 
+  const separator = todosFromDoneFile.toString().endsWith('\n') ? '' : '\n'
   writeToFile(
-    todosFromDoneFile + '\n' + completedTodos,
+    todosFromDoneFile + separator + completedTodos,
     activeFile.doneFilePath,
     activeFile.doneFileBookmark
   )


### PR DESCRIPTION
When archiving to done.txt, sleek would always write a blank line before the batch. This was because we always wrote a newline character, regardless of whether there already was one. This is now fixed by only writing it when the file doesn't end with a newline character.

Closes #810