### PR TITLE
Check word boundary in front of attribute keys

### DIFF
--- a/src/main/Date.ts
+++ b/src/main/Date.ts
@@ -41,10 +41,10 @@ function processDateWithSugar(string: string, type: string) {
 
 export function extractSpeakingDates(body: string) {
   const expressions = [
-    { pattern: /due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g, key: 'due:', type: 'relative' },
-    { pattern: /due:(\d{4}-\d{2}-\d{2})/g, key: 'due:', type: 'absolute' },
-    { pattern: /t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g, key: 't:', type: 'relative' },
-    { pattern: /t:(\d{4}-\d{2}-\d{2})/g, key: 't:', type: 'absolute' }
+    { pattern: /(?<=\b)due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g, key: 'due:', type: 'relative' },
+    { pattern: /(?<=\b)due:(\d{4}-\d{2}-\d{2})/g, key: 'due:', type: 'absolute' },
+    { pattern: /(?<=\b)t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g, key: 't:', type: 'relative' },
+    { pattern: /(?<=\b)t:(\d{4}-\d{2}-\d{2})/g, key: 't:', type: 'absolute' }
   ]
 
   const speakingDates = {

--- a/src/renderer/Grid/Renderer.tsx
+++ b/src/renderer/Grid/Renderer.tsx
@@ -34,8 +34,8 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
       { pattern: /@(\S+)/, type: 'contexts', key: '@' },
       { pattern: /(?:^|\s)\+(\S+)/, type: 'projects', key: '+' },
       { pattern: /\bh:1\b/, type: 'hidden', key: 'h:1' },
-      { pattern: /pm:(\d+)/, type: 'pm', key: 'pm:' },
-      { pattern: /rec:([^ ]+)/, type: 'rec', key: 'rec:' }
+      { pattern: /\bpm:(\d+)/, type: 'pm', key: 'pm:' },
+      { pattern: /\brec:([^ ]+)/, type: 'rec', key: 'rec:' }
     ]
 
     const replacements: {


### PR DESCRIPTION
Sleek incorrectly parsed keys ending in 't' or 'due' and incorrectly
rendered labels for attributes ending in other keys we use.

about:1234 => was parsed as threshold
foodue:1234 => was parsed as due date

foo+bar => rendered as a project label

This is fixed by checking for the word boundary in front of the key,
making sure no random other characters are directly before the key.

Fixes #794
