### PR TITLE
allow capitalisation of filenames in tabs

### DIFF
--- a/src/renderer/Header/FileTabs.scss
+++ b/src/renderer/Header/FileTabs.scss
@@ -7,7 +7,7 @@
       min-width: auto;
       min-height: auto;
       padding: 0.5em 0.5em 0.5em 1em;
-      text-transform: lowercase;
+      text-transform: none;
       display: flex;
       flex-direction: row;
       font-size: 0.8em;


### PR DESCRIPTION
Filenames in tabs were forced into lowercase. This makes two files 'foo.txt' and 'FOO.txt' in case-sensitive filesystems indistinguishable from each other. For filenames in camel case, taking into account capitalisation improves readability ('myimportanttodo.txt' vs 'MyImportantToDo.txt').

Closes #840