### PR TITLE
Fix menu bar not being hidden on startup

### DIFF
--- a/src/main/Stores.ts
+++ b/src/main/Stores.ts
@@ -213,6 +213,7 @@ SettingsStore.onDidChange('colorTheme', (colorTheme) => {
 SettingsStore.onDidChange('menuBarVisibility', (menuBarVisibility) => {
   try {
     mainWindow!.setMenuBarVisibility(menuBarVisibility)
+    mainWindow!.setAutoHideMenuBar(!menuBarVisibility)
   } catch (error: any) {
     HandleError(error)
   }  

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -111,11 +111,13 @@ const handleWindowSizeAndPosition = () => {
 
 const createMainWindow = () => {
   const shouldUseDarkColors: boolean = SettingsStore.get('shouldUseDarkColors')
+  const shouldShowMenubar: boolean = SettingsStore.get('menuBarVisibility')
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 1000,
     show: false,
     backgroundColor: shouldUseDarkColors ? '#212224' : '#fff',
+    autoHideMenuBar: !shouldShowMenubar,
     icon:
       process.platform === 'win32'
         ? nativeImage.createFromPath(windowsIcon)
@@ -132,6 +134,7 @@ const createMainWindow = () => {
   })
 
   mainWindow.once('ready-to-show', () => {
+    mainWindow.setMenuBarVisibility(shouldShowMenubar)
     mainWindow.show();
     const endTime = performance.now()
     console.log(`Startup time: ${(endTime - startTime).toFixed(2)} ms`)


### PR DESCRIPTION
Menu bar visibility was only set when the setting changed, but not on
startup. While at it, enable to use the Alt key to temporarily show the
menu bar when set to hidden.

Fixes #842
