### PR TITLE
Add command line feature to open files

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -151,6 +151,8 @@ const createMainWindow = () => {
     mainWindow.loadFile(fileURLToPath(new URL('../renderer/index.html', import.meta.url)))
   }
 
+  const isDev = process.argv[0].endsWith("node_modules/electron/dist/electron")
+  process.argv.splice(isDev ? 2 : 1).forEach(f => handleOpenFile(path.resolve(f)))
   const files: FileObject[] = (SettingsStore.get('files') as FileObject[]) || []
   if (files) {
     createFileWatcher(files)


### PR DESCRIPTION
When sleek is started from the command line, one can now provide a file
or multiple files to open in sleek.

	sleek /home/user/todo.txt	# Absolute path
	sleek ~/todo.txt		# Home path
	sleek ../todo.txt		# Relative path
	sleek ~/foo.txt ../bar.txt	# Multiple files

Closes #803
