### PR TITLE
Improve tray icon handling

### DIFF
--- a/src/main/Menu.ts
+++ b/src/main/Menu.ts
@@ -4,7 +4,6 @@ import { mainWindow, HandleCreateWindow } from './index';
 import { openFile, createFile } from './File/Dialog';
 import { handleRequestArchive } from './File/Archive';
 import { SettingsStore, FiltersStore } from './Stores';
-import { HandleTray } from './Tray';
 import { File } from '../Types';
 import appPackage from '../../package.json';
 

--- a/src/main/Stores.ts
+++ b/src/main/Stores.ts
@@ -7,7 +7,7 @@ import { dataRequest, searchString } from './DataRequest/DataRequest'
 import { userDataDirectory, HandleError } from './Shared'
 import { mainWindow } from './index'
 import { createFileWatcher } from './File/Watcher'
-import { HandleTray } from './Tray'
+import { CreateTray, DestroyTray, UpdateTrayImage, UpdateTrayMenu } from './Tray'
 import { HandleTheme } from './Theme'
 
 const distributionChannel = function(): string {
@@ -195,7 +195,7 @@ SettingsStore.onDidChange('files', (newValue: FileObject[] | undefined) => {
     if (!newValue) return false;
     
     createFileWatcher(newValue)
-    HandleTray()
+    UpdateTrayMenu()
     
   } catch (error: any) {
     HandleError(error)
@@ -218,9 +218,9 @@ SettingsStore.onDidChange('menuBarVisibility', (menuBarVisibility) => {
   }  
 })
 
-SettingsStore.onDidChange('tray', () => {
+SettingsStore.onDidChange('tray', (v: boolean) => {
   try {
-    HandleTray()
+    v ? CreateTray() : DestroyTray()
   } catch (error: any) {
     HandleError(error)
   }
@@ -228,7 +228,7 @@ SettingsStore.onDidChange('tray', () => {
 
 SettingsStore.onDidChange('invertTrayColor', () => {
   try {
-    HandleTray()
+    UpdateTrayImage()
   } catch (error: any) {
     HandleError(error)
   }

--- a/src/main/Theme.ts
+++ b/src/main/Theme.ts
@@ -1,7 +1,7 @@
 import { nativeTheme } from 'electron'
 import { SettingsStore } from './Stores'
 import { HandleError } from './Shared'
-import { HandleTray } from './Tray'
+import { UpdateTrayImage } from './Tray'
 
 nativeTheme.on('updated', (): void => {
   try {
@@ -12,7 +12,7 @@ nativeTheme.on('updated', (): void => {
     } else {
       SettingsStore.set('shouldUseDarkColors', false)
     }
-    HandleTray()
+    UpdateTrayImage()
   } catch (error: error) {
     HandleError(error)
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,12 +1,11 @@
 import { app, BrowserWindow, nativeImage } from 'electron'
 import { fileURLToPath } from 'url'
-import path from 'path'
 import fs from 'fs'
 import { SettingsStore } from './Stores.js'
 import { CreateMenu } from './Menu.js'
 import { createFileWatcher, watcher } from './File/Watcher'
 import { addFile } from './File/File'
-import { HandleTray } from './Tray'
+import { CreateTray } from './Tray'
 import macIcon from '../../resources/icon.icns?asset'
 import windowsIcon from '../../resources/icon.ico?asset'
 import linuxIcon from '../../resources/icon.png?asset'
@@ -18,14 +17,14 @@ const environment: string | undefined = process.env.NODE_ENV
 let mainWindow: BrowserWindow | null = null
 const eventListeners: Record<string, any | undefined> = {}
 let resizeTimeout: NodeJS.Timeout | undefined
-const additionalData = { myKey: 'myValue' }
 const gotTheLock = app.requestSingleInstanceLock()
 
 const HandleCreateWindow = () => {
-  if (mainWindow) {
-    mainWindow.show()
-  } else {
+  const wins = BrowserWindow.getAllWindows()
+  if (wins.length === 0) {
     createMainWindow()
+  } else {
+    wins[0].focus()
   }
 }
 
@@ -162,7 +161,6 @@ const createMainWindow = () => {
 
   const colorTheme: string = SettingsStore.get('colorTheme')
   HandleTheme(colorTheme);
-  HandleTray()
 
   eventListeners.handleClosed = handleClosed
   eventListeners.handleResize = handleResize
@@ -236,9 +234,9 @@ if (!gotTheLock) {
       startTime = performance.now()
       const tray = SettingsStore.get('tray');
       const startMinimized = SettingsStore.get('startMinimized');
+      if(tray) CreateTray()
       if(tray && startMinimized) {
         app.dock?.hide()
-        HandleTray()
       } else {
         createMainWindow()
       }


### PR DESCRIPTION
Upon startup, we basically spammed the OS with tray (re)creation, as
each update related to opened files or theming (which are fired a
lot upon startup) triggered a recreation. These recreations over a short
period of time sometimes caused the tray icon to be in a weird state,
resulting in unresponsiveness or the icon being shown twice.

Instead of always recreating the tray icon, we now update it
according to what changed exactly (either theming or the opened files).

Closes #849 and hopefully #827
