### PR TITLE
Bring GitHub actions up to date

### DIFF
--- a/.github/workflows/code-scan-update-mirror.yml
+++ b/.github/workflows/code-scan-update-mirror.yml
@@ -7,7 +7,7 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
         env:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
       - name: nodejsscan scan
         id: njsscan
         uses: ajinabraham/njsscan-action@master
@@ -38,9 +38,12 @@ jobs:
         language: ["javascript"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@master
-      - name: Set up latest available Nodejs
-        uses: actions/setup-node@master
+        uses: actions/checkout@v6
+      - name: Set up Nodejs
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+          cache: "npm"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
@@ -59,9 +62,12 @@ jobs:
         language: ["javascript"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
-      - name: Set up latest available Nodejs
-        uses: actions/setup-node@master
+        uses: actions/checkout@v6
+      - name: Set up Nodejs
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25
+          cache: "npm"
       - name: Install dependencies
         run: npm install
       - name: Build
@@ -80,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,9 +12,9 @@ jobs:
         os: [macos-latest]
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
       - name: Install Node and NPM
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: "npm"
@@ -44,9 +44,9 @@ jobs:
         os: [windows-latest]
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
       - name: Install Node and NPM
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: "npm"
@@ -70,9 +70,9 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
       - name: Install Node and NPM
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v6
         with:
           node-version: 25
           cache: "npm"


### PR DESCRIPTION
We still referenced master branches of actions/checkout and actions/setup-node. Those have been replaced 6 years ago. This caused Node.js jobs to still use Node.js 20. Switched those to their respective latest major tags and explicitly set the Node.js version.