### PR TITLE
Feature/two row view

### DIFF
--- a/src/@types/Settings.ts
+++ b/src/@types/Settings.ts
@@ -20,6 +20,7 @@ export interface SettingStore {
   menuBarVisibility: boolean;
   disableAnimations: boolean;
   compact: boolean;
+  multiLineView: boolean;
   zoom: number;
   matomo: boolean;
 

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -35,6 +35,7 @@
   "settings.6": "Sobota",
   "settings.menuBarVisibility": "Zobrazit menu v panelu",
   "settings.compact": "Kompaktní zobrazení",
+  "settings.multiLineView": "Dvouřádkové zobrazení",
   "attributes": "Atributy",
   "filters": "Filtry",
   "sorting": "Řazení",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -35,6 +35,7 @@
   "settings.6": "Samstag",
   "settings.menuBarVisibility": "Menüleiste anzeigen",
   "settings.compact": "Kompakte Ansicht",
+  "settings.multiLineView": "Zweizeilige Ansicht",
   "attributes": "Attribute",
   "filters": "Filter",
   "sorting": "Sortierung",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,6 +35,7 @@
   "settings.6": "Saturday",
   "settings.menuBarVisibility": "Show menu bar",
   "settings.compact": "Compact view",
+  "settings.multiLineView": "Two-row view",
   "attributes": "Attributes",
   "filters": "Filters",
   "sorting": "Sorting",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -35,6 +35,7 @@
   "settings.6": "Sábado",
   "settings.menuBarVisibility": "Mostrar barra de menú",
   "settings.compact": "Vista compacta",
+  "settings.multiLineView": "Vista de dos filas",
   "attributes": "Atributos",
   "filters": "Filtros",
   "sorting": "Ordenación",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -35,6 +35,7 @@
   "settings.6": "Samedi",
   "settings.menuBarVisibility": "Afficher la barre de menus",
   "settings.compact": "Vue compacte",
+  "settings.multiLineView": "Vue sur deux lignes",
   "attributes": "Attributs",
   "filters": "Filtres",
   "sorting": "Tri",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -35,6 +35,7 @@
   "settings.6": "शनिवार",
   "settings.menuBarVisibility": "मेनू बार दिखाएं",
   "settings.compact": "संकुचित दृश्य",
+  "settings.multiLineView": "दो-पंक्ति दृश्य",
   "attributes": "गुण",
   "filters": "फ़िल्टर",
   "sorting": "क्रमबद्ध करना",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -35,6 +35,7 @@
   "settings.6": "Szombat",
   "settings.menuBarVisibility": "Menüsor megjelenítése",
   "settings.compact": "Komplett nézet",
+  "settings.multiLineView": "Kétsoros nézet",
   "attributes": "Tulajdonságok",
   "filters": "Szűrők",
   "sorting": "Rendezés",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -35,6 +35,7 @@
   "settings.6": "Sabato",
   "settings.menuBarVisibility": "Mostra la barra dei menu",
   "settings.compact": "Vista compatta",
+  "settings.multiLineView": "Vista su due righe",
   "attributes": "Attributi",
   "filters": "Filtri",
   "sorting": "Ordinamento",

--- a/src/locales/jp.json
+++ b/src/locales/jp.json
@@ -35,6 +35,7 @@
   "settings.6": "土曜日",
   "settings.menuBarVisibility": "メニューバーを表示する",
   "settings.compact": "コンパクトビュー",
+  "settings.multiLineView": "2行ビュー",
   "attributes": "属性",
   "filters": "フィルター",
   "sorting": "ソート",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -35,6 +35,7 @@
   "settings.6": "토요일",
   "settings.menuBarVisibility": "메뉴 바 표시",
   "settings.compact": "컴팩트 보기",
+  "settings.multiLineView": "두 줄 보기",
   "attributes": "속성",
   "filters": "필터",
   "sorting": "정렬",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -35,6 +35,7 @@
   "settings.6": "Sobota",
   "settings.menuBarVisibility": "Pokaż pasek menu",
   "settings.compact": "Widok kompaktowy",
+  "settings.multiLineView": "Widok dwuwierszowy",
   "attributes": "Atrybuty",
   "filters": "Filtry",
   "sorting": "Sortowanie",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -35,6 +35,7 @@
   "settings.6": "Sábado",
   "settings.menuBarVisibility": "Mostrar barra de menus",
   "settings.compact": "Visão compacta",
+  "settings.multiLineView": "Vista em duas linhas",
   "attributes": "Atributos",
   "filters": "Filtros",
   "sorting": "Classificação",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -35,6 +35,7 @@
   "settings.6": "Sábado",
   "settings.menuBarVisibility": "Mostrar barra de menu",
   "settings.compact": "Visão compacta",
+  "settings.multiLineView": "Vista em duas linhas",
   "attributes": "Atributos",
   "filters": "Filtros",
   "sorting": "Ordenação",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -35,6 +35,7 @@
   "settings.6": "Суббота",
   "settings.menuBarVisibility": "Показать строку меню",
   "settings.compact": "Компактный вид",
+  "settings.multiLineView": "Двухстрочный вид",
   "attributes": "Атрибуты",
   "filters": "Фильтры",
   "sorting": "Сортировка",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -35,6 +35,7 @@
   "settings.6": "Cumartesi",
   "settings.menuBarVisibility": "Menü çubuğunu göster",
   "settings.compact": "Kompakt görünüm",
+  "settings.multiLineView": "İki satırlı görünüm",
   "attributes": "Özellikler",
   "filters": "Filtreler",
   "sorting": "Sıralama",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -35,6 +35,7 @@
   "settings.6": "周六",
   "settings.menuBarVisibility": "显示菜单栏",
   "settings.compact": "精简视图",
+  "settings.multiLineView": "双行视图",
   "attributes": "属性",
   "filters": "过滤器",
   "sorting": "排序",

--- a/src/main/Stores.ts
+++ b/src/main/Stores.ts
@@ -147,7 +147,7 @@ const migrations = {
   },
   "2.0.27": (config) => {
     console.log("Migrating settings store from 2.0.19 → 2.0.27");
-    config.set("multiLineView", config.get("multiLineView", false));
+    config.set("multiLineView", false);
   },
 };
 

--- a/src/main/Stores.ts
+++ b/src/main/Stores.ts
@@ -145,6 +145,10 @@ const migrations = {
     config.set("invertTrayColor", false);
     config.set("startMinimized", false);
   },
+  "2.0.27": (config) => {
+    console.log("Migrating settings store from 2.0.19 → 2.0.27");
+    config.set("multiLineView", config.get("multiLineView", false));
+  },
 };
 
 const rerenderDefinition = {

--- a/src/renderer/Grid/Renderer.tsx
+++ b/src/renderer/Grid/Renderer.tsx
@@ -114,38 +114,7 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
       return uri;
     };
 
-    const options: Components = {
-      p: ({ children }): JSX.Element | null => {
-        const mappedChildren = React.Children.map(children, (child) => {
-          if (typeof child !== "string") return child;
-          let modifiedChild: React.ReactNode = child;
-          let index = 0;
-          expressions.forEach(({ pattern, type }) => {
-            modifiedChild = reactStringReplace(
-              modifiedChild as string,
-              pattern,
-              (match) => {
-                index++;
-                return (
-                  <span
-                    key={`${type}-${match}-${index}`}
-                    className={
-                      IsSelected(type, filters, [match])
-                        ? "selected filter"
-                        : "filter"
-                    }
-                    data-todotxt-attribute={type}
-                  >
-                    {replacements[type](match, type)}
-                  </span>
-                );
-              },
-            );
-          });
-          return modifiedChild;
-        });
-        return mappedChildren ? <>{mappedChildren}</> : null;
-      },
+    const linkOptions: Components = {
       a: ({ children, href, ...props }): JSX.Element | null => {
         if (!children) return null;
         const childrenStr =
@@ -176,6 +145,221 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
         ) : (
           link
         );
+      },
+    };
+
+    if (settings.multiLineView) {
+      const badgePatterns: RegExp[] = [];
+      if (todoObject.tString) badgePatterns.push(new RegExp(`t:${todoObject.tString.replace(/\s/g, "\\s")}`, "g"));
+      if (todoObject.dueString) badgePatterns.push(new RegExp(`due:${todoObject.dueString.replace(/\s/g, "\\s")}`, "g"));
+      badgePatterns.push(/@\S+/g, /(?:^|\s)\+\S+/g, /\bh:1\b/g, /\bpm:\d+/g, /\brec:[^ ]+/g);
+
+      let cleanBody = todoObject.body;
+      for (const pattern of badgePatterns) {
+        cleanBody = cleanBody.replace(pattern, "");
+      }
+      cleanBody = cleanBody.replace(/\s+/g, " ").trim();
+
+      const badgeElements: React.ReactNode[] = [];
+      let badgeIndex = 0;
+
+      if (todoObject.due) {
+        badgeIndex++;
+        badgeElements.push(
+          <span
+            key={`due-${badgeIndex}`}
+            className={
+              IsSelected("due", filters, [todoObject.due])
+                ? "selected filter"
+                : "filter"
+            }
+            data-todotxt-attribute="due"
+          >
+            <DatePickerInline
+              type="due"
+              todoObject={todoObject}
+              date={todoObject.due}
+              filters={filters}
+              settings={settings}
+            />
+          </span>
+        );
+      }
+
+      if (todoObject.t) {
+        badgeIndex++;
+        badgeElements.push(
+          <span
+            key={`t-${badgeIndex}`}
+            className={
+              IsSelected("t", filters, [todoObject.t])
+                ? "selected filter"
+                : "filter"
+            }
+            data-todotxt-attribute="t"
+          >
+            <DatePickerInline
+              type="t"
+              todoObject={todoObject}
+              date={todoObject.t}
+              filters={filters}
+              settings={settings}
+            />
+          </span>
+        );
+      }
+
+      if (todoObject.projects) {
+        todoObject.projects.forEach((project) => {
+          badgeIndex++;
+          badgeElements.push(
+            <span
+              key={`projects-${project}-${badgeIndex}`}
+              className={
+                IsSelected("projects", filters, [project])
+                  ? "selected filter"
+                  : "filter"
+              }
+              data-todotxt-attribute="projects"
+            >
+              <button
+                onClick={() =>
+                  HandleFilterSelect("projects", [project], filters, false, null)
+                }
+                data-testid="datagrid-button-projects"
+              >
+                {project}
+              </button>
+            </span>
+          );
+        });
+      }
+
+      if (todoObject.contexts) {
+        todoObject.contexts.forEach((context) => {
+          badgeIndex++;
+          badgeElements.push(
+            <span
+              key={`contexts-${context}-${badgeIndex}`}
+              className={
+                IsSelected("contexts", filters, [context])
+                  ? "selected filter"
+                  : "filter"
+              }
+              data-todotxt-attribute="contexts"
+            >
+              <button
+                onClick={() =>
+                  HandleFilterSelect("contexts", [context], filters, false, null)
+                }
+                data-testid="datagrid-button-contexts"
+              >
+                {context}
+              </button>
+            </span>
+          );
+        });
+      }
+
+      if (todoObject.rec) {
+        badgeIndex++;
+        badgeElements.push(
+          <span
+            key={`rec-${badgeIndex}`}
+            className="filter"
+            data-todotxt-attribute="rec"
+          >
+            <button
+              onClick={() =>
+                HandleFilterSelect("rec", [todoObject.rec!], filters, false, null)
+              }
+              data-testid="datagrid-button-rec"
+            >
+              <Chip label="rec:" />
+              <div>{todoObject.rec}</div>
+            </button>
+          </span>
+        );
+      }
+
+      if (todoObject.pm) {
+        badgeIndex++;
+        badgeElements.push(
+          <span
+            key={`pm-${badgeIndex}`}
+            className="filter"
+            data-todotxt-attribute="pm"
+          >
+            <button
+              className="pomodoro"
+              onClick={() =>
+                HandleFilterSelect(
+                  "pm",
+                  [String(todoObject.pm)],
+                  filters,
+                  false,
+                  null,
+                )
+              }
+              data-testid="datagrid-button-pm"
+            >
+              <img src={PomodoroIcon} alt="Pomodoro" />
+              {todoObject.pm}
+            </button>
+          </span>
+        );
+      }
+
+      return (
+        <>
+          <span className="row-text">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={linkOptions}
+              urlTransform={transformURL}
+            >
+              {cleanBody}
+            </ReactMarkdown>
+          </span>
+          {badgeElements.length > 0 && (
+            <span className="row-badges">{badgeElements}</span>
+          )}
+        </>
+      );
+    }
+
+    const options: Components = {
+      ...linkOptions,
+      p: ({ children }): JSX.Element | null => {
+        const mappedChildren = React.Children.map(children, (child) => {
+          if (typeof child !== "string") return child;
+          let modifiedChild: React.ReactNode = child;
+          let index = 0;
+          expressions.forEach(({ pattern, type }) => {
+            modifiedChild = reactStringReplace(
+              modifiedChild as string,
+              pattern,
+              (match) => {
+                index++;
+                return (
+                  <span
+                    key={`${type}-${match}-${index}`}
+                    className={
+                      IsSelected(type, filters, [match])
+                        ? "selected filter"
+                        : "filter"
+                    }
+                    data-todotxt-attribute={type}
+                  >
+                    {replacements[type](match, type)}
+                  </span>
+                );
+              },
+            );
+          });
+          return modifiedChild;
+        });
+        return mappedChildren ? <>{mappedChildren}</> : null;
       },
     };
 

--- a/src/renderer/Grid/Renderer.tsx
+++ b/src/renderer/Grid/Renderer.tsx
@@ -149,126 +149,63 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
     };
 
     if (settings.multiLineView) {
-      const badgePatterns: RegExp[] = [];
-      if (todoObject.tString) badgePatterns.push(new RegExp(`t:${todoObject.tString.replace(/\s/g, "\\s")}`, "g"));
-      if (todoObject.dueString) badgePatterns.push(new RegExp(`due:${todoObject.dueString.replace(/\s/g, "\\s")}`, "g"));
-      badgePatterns.push(/@\S+/g, /(?:^|\s)\+\S+/g, /\bh:1\b/g, /\bpm:\d+/g, /\brec:[^ ]+/g);
-
       let cleanBody = todoObject.body;
-      for (const pattern of badgePatterns) {
-        cleanBody = cleanBody.replace(pattern, "");
+      for (const { pattern } of expressions) {
+        cleanBody = cleanBody.replace(new RegExp(pattern.source, "g"), "");
       }
       cleanBody = cleanBody.replace(/\s+/g, " ").trim();
 
       const badgeElements: React.ReactNode[] = [];
-      let badgeIndex = 0;
 
-      if (todoObject.due) {
-        badgeIndex++;
+      const dateBadges: Array<{ type: "due" | "t"; value: string | null }> = [
+        { type: "due", value: todoObject.due },
+        { type: "t", value: todoObject.t },
+      ];
+      dateBadges.forEach(({ type, value }) => {
+        if (!value) return;
         badgeElements.push(
           <span
-            key={`due-${badgeIndex}`}
-            className={
-              IsSelected("due", filters, [todoObject.due])
-                ? "selected filter"
-                : "filter"
-            }
-            data-todotxt-attribute="due"
+            key={type}
+            className={IsSelected(type, filters, [value]) ? "selected filter" : "filter"}
+            data-todotxt-attribute={type}
           >
             <DatePickerInline
-              type="due"
+              type={type}
               todoObject={todoObject}
-              date={todoObject.due}
+              date={value}
               filters={filters}
               settings={settings}
             />
           </span>
         );
-      }
+      });
 
-      if (todoObject.t) {
-        badgeIndex++;
-        badgeElements.push(
-          <span
-            key={`t-${badgeIndex}`}
-            className={
-              IsSelected("t", filters, [todoObject.t])
-                ? "selected filter"
-                : "filter"
-            }
-            data-todotxt-attribute="t"
-          >
-            <DatePickerInline
-              type="t"
-              todoObject={todoObject}
-              date={todoObject.t}
-              filters={filters}
-              settings={settings}
-            />
-          </span>
-        );
-      }
-
-      if (todoObject.projects) {
-        todoObject.projects.forEach((project) => {
-          badgeIndex++;
+      const listBadges: Array<{ type: "projects" | "contexts"; values: string[] | null }> = [
+        { type: "projects", values: todoObject.projects },
+        { type: "contexts", values: todoObject.contexts },
+      ];
+      listBadges.forEach(({ type, values }) => {
+        values?.forEach((value) => {
           badgeElements.push(
             <span
-              key={`projects-${project}-${badgeIndex}`}
-              className={
-                IsSelected("projects", filters, [project])
-                  ? "selected filter"
-                  : "filter"
-              }
-              data-todotxt-attribute="projects"
+              key={`${type}-${value}`}
+              className={IsSelected(type, filters, [value]) ? "selected filter" : "filter"}
+              data-todotxt-attribute={type}
             >
               <button
-                onClick={() =>
-                  HandleFilterSelect("projects", [project], filters, false, null)
-                }
-                data-testid="datagrid-button-projects"
+                onClick={() => HandleFilterSelect(type, [value], filters, false, null)}
+                data-testid={`datagrid-button-${type}`}
               >
-                {project}
+                {value}
               </button>
             </span>
           );
         });
-      }
-
-      if (todoObject.contexts) {
-        todoObject.contexts.forEach((context) => {
-          badgeIndex++;
-          badgeElements.push(
-            <span
-              key={`contexts-${context}-${badgeIndex}`}
-              className={
-                IsSelected("contexts", filters, [context])
-                  ? "selected filter"
-                  : "filter"
-              }
-              data-todotxt-attribute="contexts"
-            >
-              <button
-                onClick={() =>
-                  HandleFilterSelect("contexts", [context], filters, false, null)
-                }
-                data-testid="datagrid-button-contexts"
-              >
-                {context}
-              </button>
-            </span>
-          );
-        });
-      }
+      });
 
       if (todoObject.rec) {
-        badgeIndex++;
         badgeElements.push(
-          <span
-            key={`rec-${badgeIndex}`}
-            className="filter"
-            data-todotxt-attribute="rec"
-          >
+          <span key="rec" className="filter" data-todotxt-attribute="rec">
             <button
               onClick={() =>
                 HandleFilterSelect("rec", [todoObject.rec!], filters, false, null)
@@ -283,13 +220,8 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
       }
 
       if (todoObject.pm) {
-        badgeIndex++;
         badgeElements.push(
-          <span
-            key={`pm-${badgeIndex}`}
-            className="filter"
-            data-todotxt-attribute="pm"
-          >
+          <span key="pm" className="filter" data-todotxt-attribute="pm">
             <button
               className="pomodoro"
               onClick={() =>
@@ -312,9 +244,7 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
 
       const multiLineComponents: Components = {
         ...linkOptions,
-        p: ({ children }): JSX.Element | null => {
-          return <>{children}</>;
-        },
+        p: ({ children }): JSX.Element | null => <>{children}</>,
       };
 
       return (

--- a/src/renderer/Grid/Renderer.tsx
+++ b/src/renderer/Grid/Renderer.tsx
@@ -310,12 +310,19 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
         );
       }
 
+      const multiLineComponents: Components = {
+        ...linkOptions,
+        p: ({ children }): JSX.Element | null => {
+          return <>{children}</>;
+        },
+      };
+
       return (
         <>
           <span className="row-text">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
-              components={linkOptions}
+              components={multiLineComponents}
               urlTransform={transformURL}
             >
               {cleanBody}

--- a/src/renderer/Grid/Row.scss
+++ b/src/renderer/Grid/Row.scss
@@ -68,6 +68,22 @@
   }
 }
 
+.multiLineView {
+  .row {
+    .row-text {
+      flex: 1;
+      min-width: 0;
+    }
+    .row-badges {
+      width: 100%;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25em;
+      align-items: center;
+    }
+  }
+}
+
 .dark {
   .row {
     border-color: Variables.$dark-grey;

--- a/src/renderer/Grid/Row.scss
+++ b/src/renderer/Grid/Row.scss
@@ -36,6 +36,10 @@
   }
 }
 
+.row-content {
+  display: contents;
+}
+
 .compact {
   .row {
     padding: 0.3em;
@@ -70,6 +74,18 @@
 
 .multiLineView {
   .row {
+    align-items: flex-start;
+    padding: 0.3em 0.5em;
+
+    .row-content {
+      display: flex;
+      flex-wrap: wrap;
+      flex: 1;
+      min-width: 0;
+      gap: 0.25em;
+      align-items: center;
+    }
+
     .row-text {
       flex: 1;
       min-width: 0;

--- a/src/renderer/Grid/Row.tsx
+++ b/src/renderer/Grid/Row.tsx
@@ -174,67 +174,69 @@ const Row: React.FC<RowProps> = memo(
             onChange={handleCheckboxChange}
           />
 
-          {(settings.sorting[0].value != "priority" || settings.fileSorting) &&
-            todoObject.priority && (
-              <span
-                data-todotxt-attribute="priority"
-                data-todotxt-value={todoObject.priority}
-                className={
-                  IsSelected("priority", filters, [todoObject.priority])
-                    ? "selected filter"
-                    : "filter"
-                }
-                data-testid={`datagrid-button-priority`}
-              >
-                <button
-                  onClick={() =>
-                    HandleFilterSelect(
-                      "priority",
-                      [todoObject.priority!],
-                      filters,
-                      false,
-                      null,
-                    )
+          <div className="row-content">
+            {(settings.sorting[0].value != "priority" || settings.fileSorting) &&
+              todoObject.priority && (
+                <span
+                  data-todotxt-attribute="priority"
+                  data-todotxt-value={todoObject.priority}
+                  className={
+                    IsSelected("priority", filters, [todoObject.priority])
+                      ? "selected filter"
+                      : "filter"
                   }
+                  data-testid={`datagrid-button-priority`}
                 >
-                  {todoObject.priority}
-                </button>
-              </span>
+                  <button
+                    onClick={() =>
+                      HandleFilterSelect(
+                        "priority",
+                        [todoObject.priority!],
+                        filters,
+                        false,
+                        null,
+                      )
+                    }
+                  >
+                    {todoObject.priority}
+                  </button>
+                </span>
+              )}
+
+            {todoObject.completed && (
+              <Tooltip
+                title={`${t("shared.attributeMapping.completed")} ${todoObject.completed}`}
+                arrow
+              >
+                <EventAvailableIcon
+                  data-todotxt-attribute="completed"
+                  data-testid={`datagrid-button-completed`}
+                />
+              </Tooltip>
             )}
 
-          {todoObject.completed && (
-            <Tooltip
-              title={`${t("shared.attributeMapping.completed")} ${todoObject.completed}`}
-              arrow
-            >
-              <EventAvailableIcon
-                data-todotxt-attribute="completed"
-                data-testid={`datagrid-button-completed`}
-              />
-            </Tooltip>
-          )}
+            {todoObject.created && (
+              <Tooltip
+                title={`${t("shared.attributeMapping.created")} ${todoObject.created}`}
+                arrow
+              >
+                <EventNoteIcon
+                  data-todotxt-attribute="created"
+                  data-testid={`datagrid-button-created`}
+                />
+              </Tooltip>
+            )}
 
-          {todoObject.created && (
-            <Tooltip
-              title={`${t("shared.attributeMapping.created")} ${todoObject.created}`}
-              arrow
-            >
-              <EventNoteIcon
-                data-todotxt-attribute="created"
-                data-testid={`datagrid-button-created`}
-              />
-            </Tooltip>
-          )}
+            {todoObject.hidden && (
+              <VisibilityOffIcon data-todotxt-attribute="hidden " />
+            )}
 
-          {todoObject.hidden && (
-            <VisibilityOffIcon data-todotxt-attribute="hidden " />
-          )}
-
-          <RendererComponent
-            todoObject={todoObject}
-            filters={filters ? filters : ({} as Filters)}
-            settings={settings}
-          />
+            <RendererComponent
+              todoObject={todoObject}
+              filters={filters ? filters : ({} as Filters)}
+              settings={settings}
+            />
+          </div>
         </li>
       </>
     );

--- a/src/renderer/Settings/Settings.tsx
+++ b/src/renderer/Settings/Settings.tsx
@@ -136,7 +136,7 @@ const SettingsComponent: React.FC<SettingsComponentProps> = memo(
     }, [settings.language]);
 
     useEffect(() => {
-      const { shouldUseDarkColors, zoom, compact, disableAnimations } =
+      const { shouldUseDarkColors, zoom, compact, disableAnimations, multiLineView } =
         settings;
       const adjustedFontSize = Math.round(14 * (zoom / 100));
 
@@ -152,7 +152,7 @@ const SettingsComponent: React.FC<SettingsComponentProps> = memo(
 
       document.body.classList.toggle("disableAnimations", disableAnimations);
       document.body.classList.toggle("compact", compact);
-      document.body.classList.toggle("multiLineView", settings.multiLineView);
+      document.body.classList.toggle("multiLineView", multiLineView);
       document.body.classList.toggle("dark", shouldUseDarkColors);
       document.body.classList.toggle("light", !shouldUseDarkColors);
 

--- a/src/renderer/Settings/Settings.tsx
+++ b/src/renderer/Settings/Settings.tsx
@@ -76,6 +76,9 @@ const visibleSettings: VisibleSettings = {
   compact: {
     style: "toggle",
   },
+  multiLineView: {
+    style: "toggle",
+  },
   notificationsAllowed: {
     style: "toggle",
   },
@@ -149,17 +152,19 @@ const SettingsComponent: React.FC<SettingsComponentProps> = memo(
 
       document.body.classList.toggle("disableAnimations", disableAnimations);
       document.body.classList.toggle("compact", compact);
+      document.body.classList.toggle("multiLineView", settings.multiLineView);
       document.body.classList.toggle("dark", shouldUseDarkColors);
       document.body.classList.toggle("light", !shouldUseDarkColors);
 
       return () => {
-        document.body.classList.remove("dark", "light", "compact");
+        document.body.classList.remove("dark", "light", "compact", "multiLineView");
       };
     }, [
       settings.shouldUseDarkColors,
       settings.zoom,
       settings.compact,
       settings.disableAnimations,
+      settings.multiLineView,
     ]);
 
     const { t } = useTranslation();


### PR DESCRIPTION
This branch introduces an optional two-row view for displaying todos, where badges (due dates, projects, contexts, etc.) appear on a second row below the todo text.

- Adds a multiLineView setting with automatic migration for existing users
- Adds a settings UI toggle to enable/disable the two-row view
- When enabled, badge patterns are cleaned from the todo body text and rendered in a dedicated row-badges container
- Includes localized labels for all supported languages