### PR TITLE
Feature/inprogress todo state

### DIFF
--- a/src/@types/Todo.ts
+++ b/src/@types/Todo.ts
@@ -50,6 +50,7 @@ export type AttributeKey =
   | "rec"
   | "pm"
   | "hidden"
+  | "inprogress"
   | "created"
   | "completed";
 

--- a/src/@types/Todo.ts
+++ b/src/@types/Todo.ts
@@ -14,6 +14,7 @@ export interface TodoObject {
 
   priority: string | null;
   hidden: boolean;
+  inprogress: boolean;
   due: string | null;
   dueString: string | null;
   t: string | null;

--- a/src/main/Attributes.ts
+++ b/src/main/Attributes.ts
@@ -26,6 +26,7 @@ let attributes: Attributes = {
   rec: {},
   pm: {},
   hidden: {},
+  inprogress: {},
   created: {},
   completed: {},
 };

--- a/src/main/DataRequest/ChangeCompleteState.test.ts
+++ b/src/main/DataRequest/ChangeCompleteState.test.ts
@@ -41,6 +41,10 @@ describe("changeCompleteState", () => {
       changeCompleteState(todo, true);
       expect(createRecurringTodo).toHaveBeenCalledWith(todo, "1b");
     });
+    it("removes inprogress extension when marking complete", () => {
+      const r = changeCompleteState("My todo inprogress:1", true);
+      expect(r).not.toContain("inprogress:1");
+    });
   });
 
   describe("change to uncompleted", () => {

--- a/src/main/DataRequest/ChangeCompleteState.ts
+++ b/src/main/DataRequest/ChangeCompleteState.ts
@@ -27,6 +27,8 @@ function changeCompleteState(string: string, state: boolean): string {
       JsTodoTxtObject.setPriority(null);
       JsTodoTxtObject.setExtension("pri", currentPriority);
     }
+
+    JsTodoTxtObject.removeExtension("inprogress");
   } else {
     JsTodoTxtObject.setCompleted(null);
     restorePreviousPriority(JsTodoTxtObject);

--- a/src/main/DataRequest/CreateTodoObjects.ts
+++ b/src/main/DataRequest/CreateTodoObjects.ts
@@ -60,6 +60,9 @@ function createTodoObject(
   const hidden = extensions.some(
     (extension) => extension.key === "h" && extension.value === "1",
   );
+  const inprogress = extensions.some(
+    (extension) => extension.key === "inprogress" && extension.value === "1",
+  );
   const stringPm: string | null =
     extensions.find((extension) => extension.key === "pm")?.value || null;
   const rec =
@@ -110,6 +113,7 @@ function createTodoObject(
     tString,
     rec,
     hidden,
+    inprogress,
     pm,
     string: content,
   };

--- a/src/main/DataRequest/DataRequest.ts
+++ b/src/main/DataRequest/DataRequest.ts
@@ -9,7 +9,7 @@ import {
 } from "../Filters/Filters";
 import { updateAttributes, attributes } from "../Attributes";
 import { createTodoObjects } from "./CreateTodoObjects";
-import { sortTodoObjects, sortInProgressFirst } from "./Sort";
+import { sortTodoObjects, sortInProgressFirst, sortCompletedLast } from "./Sort";
 import { groupTodoObjects } from "./Group";
 import {
   Filters,
@@ -47,6 +47,7 @@ function dataRequest(passedSearchString: string = ""): RequestedData | null {
         rec: {},
         pm: {},
         hidden: {},
+        inprogress: {},
         created: {},
         completed: {},
       },
@@ -59,6 +60,7 @@ function dataRequest(passedSearchString: string = ""): RequestedData | null {
         rec: [],
         pm: [],
         hidden: [],
+        inprogress: [],
         created: [],
         completed: [],
       },
@@ -122,16 +124,7 @@ function dataRequest(passedSearchString: string = ""): RequestedData | null {
     todoObjects.sort((a, b) => sortTodoObjects(a, b, sorting));
     todoData = groupTodoObjects(todoObjects, sorting[0].value);
 
-    const sortCompletedLast = SettingsStore.get("sortCompletedLast");
-    if (sortCompletedLast) {
-      for (const group of todoData) {
-        group.todoObjects.sort((a, b) => {
-          if (a.complete && !b.complete) return 1;
-          if (!a.complete && b.complete) return -1;
-          return 0;
-        });
-      }
-    }
+    if (SettingsStore.get("sortCompletedLast")) sortCompletedLast(todoData);
   }
 
   sortInProgressFirst(todoData);

--- a/src/main/DataRequest/DataRequest.ts
+++ b/src/main/DataRequest/DataRequest.ts
@@ -9,7 +9,7 @@ import {
 } from "../Filters/Filters";
 import { updateAttributes, attributes } from "../Attributes";
 import { createTodoObjects } from "./CreateTodoObjects";
-import { sortTodoObjects } from "./Sort";
+import { sortTodoObjects, sortInProgressFirst } from "./Sort";
 import { groupTodoObjects } from "./Group";
 import {
   Filters,
@@ -102,6 +102,8 @@ function dataRequest(passedSearchString: string = ""): RequestedData | null {
       }
     }
   }
+
+  sortInProgressFirst(todoData);
 
   const requestedData: RequestedData = {
     todoData,

--- a/src/main/DataRequest/Sort.test.ts
+++ b/src/main/DataRequest/Sort.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "vitest";
-import { sortTodoObjects, sortInProgressFirst } from "./Sort";
+import { sortTodoObjects, sortInProgressFirst, sortCompletedLast } from "./Sort";
 import { createTodoObject } from "./CreateTodoObjects";
 import { TodoData } from "@sleek-types";
 
@@ -184,5 +184,80 @@ describe("sortInProgressFirst", () => {
     expect(todoData[0].todoObjects[1].body).toBe("Todo 1");
     expect(todoData[0].todoObjects[2].body).toBe("Todo 2");
     expect(todoData[0].todoObjects[3].body).toBe("Todo 4");
+  });
+});
+
+describe("sortCompletedLast", () => {
+  it("sorts completed items to the bottom of each group", () => {
+    const todoData: TodoData = [
+      {
+        title: "A",
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "x Todo A"),
+          createTodoObject(1, "Todo B"),
+          createTodoObject(1, "x Todo C"),
+        ],
+      },
+    ];
+
+    sortCompletedLast(todoData);
+
+    expect(todoData[0].todoObjects[0].complete).toBe(false);
+    expect(todoData[0].todoObjects[1].complete).toBe(true);
+    expect(todoData[0].todoObjects[2].complete).toBe(true);
+  });
+
+  it("sorts completed items last across multiple groups", () => {
+    const todoData: TodoData = [
+      {
+        title: "Group A",
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "x Todo 1"),
+          createTodoObject(1, "Todo 2"),
+        ],
+      },
+      {
+        title: "Group B",
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "Todo 3"),
+          createTodoObject(1, "x Todo 4"),
+          createTodoObject(1, "Todo 5"),
+        ],
+      },
+    ];
+
+    sortCompletedLast(todoData);
+
+    expect(todoData[0].todoObjects[0].complete).toBe(false);
+    expect(todoData[0].todoObjects[1].complete).toBe(true);
+
+    expect(todoData[1].todoObjects[0].complete).toBe(false);
+    expect(todoData[1].todoObjects[1].complete).toBe(false);
+    expect(todoData[1].todoObjects[2].complete).toBe(true);
+  });
+
+  it("preserves relative order of non-completed items", () => {
+    const todoData: TodoData = [
+      {
+        title: null,
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "Todo 1"),
+          createTodoObject(1, "x Todo 2"),
+          createTodoObject(1, "Todo 3"),
+          createTodoObject(1, "Todo 4"),
+        ],
+      },
+    ];
+
+    sortCompletedLast(todoData);
+
+    expect(todoData[0].todoObjects[0].body).toBe("Todo 1");
+    expect(todoData[0].todoObjects[1].body).toBe("Todo 3");
+    expect(todoData[0].todoObjects[2].body).toBe("Todo 4");
+    expect(todoData[0].todoObjects[3].body).toBe("x Todo 2");
   });
 });

--- a/src/main/DataRequest/Sort.test.ts
+++ b/src/main/DataRequest/Sort.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it } from "vitest";
-import { sortTodoObjects } from "./Sort";
+import { sortTodoObjects, sortInProgressFirst } from "./Sort";
 import { createTodoObject } from "./CreateTodoObjects";
+import { TodoData } from "@sleek-types";
 
 vi.mock("../Shared", () => ({
   lineBreakPlaceholder: "[LB]",
@@ -108,5 +109,80 @@ describe("sortTodoObjects", () => {
         [{ value: "pm", invert: true }],
       ),
     ).toBe(1);
+  });
+});
+
+describe("sortInProgressFirst", () => {
+  it("sorts inprogress items to the top of each group", () => {
+    const todoData: TodoData = [
+      {
+        title: "A",
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "Todo A"),
+          createTodoObject(1, "Todo B inprogress:1"),
+          createTodoObject(1, "Todo C"),
+        ],
+      },
+    ];
+
+    sortInProgressFirst(todoData);
+
+    expect(todoData[0].todoObjects[0].inprogress).toBe(true);
+    expect(todoData[0].todoObjects[1].inprogress).toBe(false);
+    expect(todoData[0].todoObjects[2].inprogress).toBe(false);
+  });
+
+  it("sorts all inprogress items first across multiple groups", () => {
+    const todoData: TodoData = [
+      {
+        title: "Group A",
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "Todo 1"),
+          createTodoObject(1, "Todo 2 inprogress:1"),
+        ],
+      },
+      {
+        title: "Group B",
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "Todo 3 inprogress:1"),
+          createTodoObject(1, "Todo 4"),
+          createTodoObject(1, "Todo 5 inprogress:1"),
+        ],
+      },
+    ];
+
+    sortInProgressFirst(todoData);
+
+    expect(todoData[0].todoObjects[0].inprogress).toBe(true);
+    expect(todoData[0].todoObjects[1].inprogress).toBe(false);
+
+    expect(todoData[1].todoObjects[0].inprogress).toBe(true);
+    expect(todoData[1].todoObjects[1].inprogress).toBe(true);
+    expect(todoData[1].todoObjects[2].inprogress).toBe(false);
+  });
+
+  it("preserves relative order of non-inprogress items", () => {
+    const todoData: TodoData = [
+      {
+        title: null,
+        visible: true,
+        todoObjects: [
+          createTodoObject(1, "Todo 1"),
+          createTodoObject(1, "Todo 2"),
+          createTodoObject(1, "Todo 3 inprogress:1"),
+          createTodoObject(1, "Todo 4"),
+        ],
+      },
+    ];
+
+    sortInProgressFirst(todoData);
+
+    expect(todoData[0].todoObjects[0].body).toBe("Todo 3 inprogress:1");
+    expect(todoData[0].todoObjects[1].body).toBe("Todo 1");
+    expect(todoData[0].todoObjects[2].body).toBe("Todo 2");
+    expect(todoData[0].todoObjects[3].body).toBe("Todo 4");
   });
 });

--- a/src/main/DataRequest/Sort.ts
+++ b/src/main/DataRequest/Sort.ts
@@ -1,4 +1,4 @@
-import { Sorting, TodoObject } from "@sleek-types";
+import { Sorting, TodoData, TodoObject } from "@sleek-types";
 
 const compareValues = (
   a: string | string[] | number | boolean | null,
@@ -36,4 +36,14 @@ const sortTodoObjects = (
   return 0;
 };
 
-export { sortTodoObjects };
+const sortInProgressFirst = (todoData: TodoData): void => {
+  for (const group of todoData) {
+    group.todoObjects.sort((a, b) => {
+      if (a.inprogress && !b.inprogress) return -1;
+      if (!a.inprogress && b.inprogress) return 1;
+      return 0;
+    });
+  }
+};
+
+export { sortTodoObjects, sortInProgressFirst };

--- a/src/main/DataRequest/Sort.ts
+++ b/src/main/DataRequest/Sort.ts
@@ -46,4 +46,14 @@ const sortInProgressFirst = (todoData: TodoData): void => {
   }
 };
 
-export { sortTodoObjects, sortInProgressFirst };
+const sortCompletedLast = (todoData: TodoData): void => {
+  for (const group of todoData) {
+    group.todoObjects.sort((a, b) => {
+      if (a.complete && !b.complete) return 1;
+      if (!a.complete && b.complete) return -1;
+      return 0;
+    });
+  }
+};
+
+export { sortTodoObjects, sortInProgressFirst, sortCompletedLast };

--- a/src/main/IpcMain.ts
+++ b/src/main/IpcMain.ts
@@ -60,7 +60,7 @@ function handleWriteTodoToFile(
   attributeValue: string,
 ) {
   try {
-    if (attributeType && attributeValue) {
+    if (attributeType) {
       const todoObject = createTodoObject(
         index,
         string,

--- a/src/renderer/Grid/Renderer.tsx
+++ b/src/renderer/Grid/Renderer.tsx
@@ -39,6 +39,7 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
         { pattern: /@(\S+)/, type: "contexts", key: "@" },
         { pattern: /(?:^|\s)\+(\S+)/, type: "projects", key: "+" },
         { pattern: /\bh:1\b/, type: "hidden", key: "h:1" },
+        { pattern: /\binprogress:1\b/, type: "inprogress", key: "inprogress:1" },
         { pattern: /\bpm:(\d+)/, type: "pm", key: "pm:" },
         { pattern: /\brec:([^ ]+)/, type: "rec", key: "rec:" },
       ];
@@ -108,6 +109,7 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
         </button>
       ),
       hidden: () => null as React.ReactNode,
+      inprogress: () => null as React.ReactNode,
     };
 
     const transformURL = (uri: string): string => {

--- a/src/renderer/Grid/Row.scss
+++ b/src/renderer/Grid/Row.scss
@@ -26,6 +26,9 @@
   &[data-hidden="true"] {
     filter: opacity(50%) grayscale(100%);
   }
+  &[data-inprogress="true"] {
+    border-left-color: #ffa726;
+  }
   &:last-child {
     border-bottom-left-radius: 0.25em;
   }

--- a/src/renderer/Grid/Row.test.tsx
+++ b/src/renderer/Grid/Row.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Row from "./Row";
+import { TodoObject, Filters, SettingStore } from "@sleek-types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      changeLanguage: vi.fn(),
+    },
+  }),
+}));
+
+const mockIpcRendererSend = vi.spyOn(window.api.ipcRenderer, "send");
+
+const baseTodo: TodoObject = {
+  body: "Test todo",
+  lineNumber: 1,
+  complete: false,
+  created: null,
+  completed: null,
+  contexts: null,
+  projects: null,
+  priority: null,
+  hidden: false,
+  inprogress: false,
+  due: null,
+  dueString: null,
+  t: null,
+  tString: null,
+  rec: null,
+  pm: null,
+  string: "Test todo",
+  notify: false,
+};
+
+const baseSettings: SettingStore = {
+  appendCreationDate: false,
+  convertRelativeToAbsoluteDates: false,
+  useHumanFriendlyDates: false,
+  bulkTodoCreation: false,
+  weekStart: 1,
+  language: "en",
+  tray: false,
+  invertTrayColor: false,
+  startMinimized: false,
+  notificationsAllowed: false,
+  notificationThreshold: 0,
+  colorTheme: "system",
+  menuBarVisibility: false,
+  disableAnimations: false,
+  compact: false,
+  zoom: 1,
+  matomo: false,
+  showCompleted: false,
+  showHidden: false,
+  fileSorting: false,
+  sortCompletedLast: false,
+  dueDateInTheFuture: false,
+  files: [],
+  sorting: [{ invert: false, value: "priority" }],
+  windowDimensions: null,
+  windowMaximized: false,
+  windowPosition: null,
+  isDrawerOpen: false,
+  isNavigationOpen: false,
+  isSearchOpen: false,
+  accordionOpenState: [],
+  showFileTabs: false,
+  shouldUseDarkColors: false,
+  customStylesPath: "",
+  excludeLinesWithPrefix: [],
+  chokidarOptions: {},
+  __internal__: {
+    migrations: {
+      version: "",
+    },
+  },
+  channel: "",
+  anonymousUserId: "",
+};
+
+const baseFilters: Filters = {
+  priority: [],
+  due: [],
+  t: [],
+  contexts: [],
+  projects: [],
+  rec: [],
+  inprogress: [],
+  pm: [],
+  hidden: [],
+  created: [],
+  completed: [],
+};
+
+const renderRow = (todo: Partial<TodoObject> = {}) => {
+  const todoObject = { ...baseTodo, ...todo };
+  return render(
+    <Row
+      todoObject={todoObject}
+      filters={baseFilters}
+      setDialogOpen={() => {}}
+      setTodoObject={() => {}}
+      setContextMenu={() => {}}
+      setPromptItem={() => {}}
+      settings={baseSettings}
+    />,
+  );
+};
+
+describe("Row", () => {
+  beforeEach(() => {
+    mockIpcRendererSend.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should send complete toggle on regular checkbox click", () => {
+    renderRow();
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    expect(mockIpcRendererSend).toHaveBeenCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      true,
+      false,
+    );
+  });
+
+  it("should send inprogress toggle and NOT complete toggle on ctrl+click", () => {
+    renderRow();
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.mouseDown(checkbox, { ctrlKey: true, button: 0 });
+    fireEvent.click(checkbox, { ctrlKey: true, button: 0 });
+
+    expect(mockIpcRendererSend).toHaveBeenCalledTimes(1);
+    expect(mockIpcRendererSend).toHaveBeenCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      false,
+      "inprogress",
+      "1",
+    );
+  });
+
+  it("should send inprogress toggle and NOT complete toggle on middle-click", () => {
+    renderRow();
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.mouseDown(checkbox, { button: 1 });
+    fireEvent.click(checkbox, { button: 1 });
+
+    expect(mockIpcRendererSend).toHaveBeenCalledTimes(1);
+    expect(mockIpcRendererSend).toHaveBeenCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      false,
+      "inprogress",
+      "1",
+    );
+  });
+
+  it("should toggle off inprogress when todo is already inprogress", () => {
+    renderRow({ inprogress: true });
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.mouseDown(checkbox, { ctrlKey: true, button: 0 });
+    fireEvent.click(checkbox, { ctrlKey: true, button: 0 });
+
+    expect(mockIpcRendererSend).toHaveBeenCalledTimes(1);
+    expect(mockIpcRendererSend).toHaveBeenCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      false,
+      "inprogress",
+      "",
+    );
+  });
+
+  it("should not toggle inprogress when todo is already complete", () => {
+    renderRow({ complete: true });
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.mouseDown(checkbox, { ctrlKey: true, button: 0 });
+    fireEvent.click(checkbox, { ctrlKey: true, button: 0 });
+
+    expect(mockIpcRendererSend).not.toHaveBeenCalled();
+  });
+
+  it("should never mark as done on repeated ctrl+clicks", () => {
+    const { rerender } = renderRow();
+    const checkbox = screen.getByRole("checkbox");
+
+    fireEvent.mouseDown(checkbox, { ctrlKey: true, button: 0 });
+    fireEvent.click(checkbox, { ctrlKey: true, button: 0 });
+    expect(mockIpcRendererSend).toHaveBeenCalledTimes(1);
+    expect(mockIpcRendererSend).toHaveBeenLastCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      false,
+      "inprogress",
+      "1",
+    );
+
+    mockIpcRendererSend.mockClear();
+
+    rerender(
+      <Row
+        todoObject={{ ...baseTodo, inprogress: true }}
+        filters={baseFilters}
+        setDialogOpen={() => {}}
+        setTodoObject={() => {}}
+        setContextMenu={() => {}}
+        setPromptItem={() => {}}
+        settings={baseSettings}
+      />,
+    );
+
+    fireEvent.mouseDown(checkbox, { ctrlKey: true, button: 0 });
+    fireEvent.click(checkbox, { ctrlKey: true, button: 0 });
+    expect(mockIpcRendererSend).toHaveBeenCalledTimes(1);
+    expect(mockIpcRendererSend).toHaveBeenLastCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      false,
+      "inprogress",
+      "",
+    );
+
+    mockIpcRendererSend.mockClear();
+
+    rerender(
+      <Row
+        todoObject={{ ...baseTodo, inprogress: false }}
+        filters={baseFilters}
+        setDialogOpen={() => {}}
+        setTodoObject={() => {}}
+        setContextMenu={() => {}}
+        setPromptItem={() => {}}
+        settings={baseSettings}
+      />,
+    );
+
+    fireEvent.mouseDown(checkbox, { ctrlKey: true, button: 0 });
+    fireEvent.click(checkbox, { ctrlKey: true, button: 0 });
+    expect(mockIpcRendererSend).toHaveBeenCalledTimes(1);
+    expect(mockIpcRendererSend).toHaveBeenLastCalledWith(
+      "writeSingleTodoToFile",
+      1,
+      "Test todo",
+      false,
+      "inprogress",
+      "1",
+    );
+
+    for (const call of mockIpcRendererSend.mock.calls) {
+      expect(call[3]).not.toBe(true);
+    }
+  });
+});

--- a/src/renderer/Grid/Row.tsx
+++ b/src/renderer/Grid/Row.tsx
@@ -3,6 +3,7 @@ import Checkbox from "@mui/material/Checkbox";
 import Tooltip from "@mui/material/Tooltip";
 import CircleChecked from "@mui/icons-material/CheckCircle";
 import CircleUnchecked from "@mui/icons-material/RadioButtonUnchecked";
+import IndeterminateCheckBox from "@mui/icons-material/IndeterminateCheckBox";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import EventAvailableIcon from "@mui/icons-material/EventAvailable";
 import EventNoteIcon from "@mui/icons-material/EventNote";
@@ -90,6 +91,21 @@ const Row: React.FC<RowProps> = memo(
       );
     };
 
+    const handleInprogressToggle = (
+      event: React.MouseEvent,
+    ): void => {
+      if (todoObject.complete) return;
+      const attributeValue = todoObject.inprogress ? "" : "1";
+      ipcRenderer.send(
+        "writeSingleTodoToFile",
+        todoObject.lineNumber,
+        todoObject.string,
+        false,
+        "inprogress",
+        attributeValue,
+      );
+    };
+
     const preventDialog = (clickedElement): boolean => {
       let match = false;
 
@@ -159,6 +175,7 @@ const Row: React.FC<RowProps> = memo(
           className="row"
           data-complete={todoObject.complete}
           data-hidden={todoObject.hidden}
+          data-inprogress={todoObject.inprogress}
           onClick={(event) => handleRowClick(event)}
           onKeyDown={(event) => handleRowClick(event)}
           onContextMenu={(event) => handleContextMenu(event, todoObject.string)}
@@ -169,9 +186,17 @@ const Row: React.FC<RowProps> = memo(
           <Checkbox
             icon={<CircleUnchecked />}
             checkedIcon={<CircleChecked />}
+            indeterminateIcon={<IndeterminateCheckBox />}
             tabIndex={0}
             checked={todoObject.complete}
+            indeterminate={todoObject.inprogress}
             onChange={handleCheckboxChange}
+            onMouseDown={(event) => {
+              if (event.button === 1 || event.ctrlKey) {
+                event.preventDefault();
+                handleInprogressToggle(event);
+              }
+            }}
           />
 
           {(settings.sorting[0].value != "priority" || settings.fileSorting) &&
@@ -227,7 +252,7 @@ const Row: React.FC<RowProps> = memo(
           )}
 
           {todoObject.hidden && (
-            <VisibilityOffIcon data-todotxt-attribute="hidden " />
+            <VisibilityOffIcon data-todotxt-attribute="hidden" />
           )}
 
           <RendererComponent

--- a/src/renderer/Grid/Row.tsx
+++ b/src/renderer/Grid/Row.tsx
@@ -96,9 +96,7 @@ const Row: React.FC<RowProps> = memo(
       );
     };
 
-    const handleInprogressToggle = (
-      event: React.MouseEvent,
-    ): void => {
+    const handleInprogressToggle = (): void => {
       if (todoObject.complete) return;
       const attributeValue = todoObject.inprogress ? "" : "1";
       ipcRenderer.send(
@@ -221,7 +219,7 @@ const Row: React.FC<RowProps> = memo(
               if (event.button === 1 || event.ctrlKey) {
                 event.preventDefault();
                 skipNextOnChange.current = true;
-                handleInprogressToggle(event);
+                handleInprogressToggle();
               } else {
                 skipNextOnChange.current = false;
               }

--- a/src/renderer/Grid/Row.tsx
+++ b/src/renderer/Grid/Row.tsx
@@ -42,6 +42,7 @@ const Row: React.FC<RowProps> = memo(
     settings,
   }) => {
     const { t } = useTranslation();
+    const skipNextOnChange = React.useRef(false);
 
     const handleConfirmDelete = (): void => {
       if (todoObject)
@@ -82,6 +83,10 @@ const Row: React.FC<RowProps> = memo(
     const handleCheckboxChange = (
       event: React.ChangeEvent<HTMLInputElement>,
     ): void => {
+      if (skipNextOnChange.current) {
+        skipNextOnChange.current = false;
+        return;
+      }
       ipcRenderer.send(
         "writeSingleTodoToFile",
         todoObject.lineNumber,
@@ -191,10 +196,23 @@ const Row: React.FC<RowProps> = memo(
             checked={todoObject.complete}
             indeterminate={todoObject.inprogress}
             onChange={handleCheckboxChange}
+            slotProps={{
+              input: {
+                onClick: (event: React.MouseEvent<HTMLInputElement>) => {
+                  if (event.ctrlKey) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }
+                },
+              },
+            }}
             onMouseDown={(event) => {
               if (event.button === 1 || event.ctrlKey) {
                 event.preventDefault();
+                skipNextOnChange.current = true;
                 handleInprogressToggle(event);
+              } else {
+                skipNextOnChange.current = false;
               }
             }}
           />


### PR DESCRIPTION
This branch adds support for tracking in-progress todo items via an inprogress extension.

- Adds inprogress: boolean to the TodoObject type
- Parses the inprogress:1 extension when loading todos
- Displays an orange left border on in-progress todos for visual identification
- Checkbox shows an indeterminate state when a todo is in progress
- Adds Ctrl+click and middle-click on the checkbox to toggle the in-progress state
- Automatically removes the inprogress extension when a todo is marked complete
- Includes unit test verifying the cleanup behavior