### PR TITLE
Fix auto-insertion of creation date on completion

### DIFF
--- a/src/main/DataRequest/ChangeCompleteState.test.ts
+++ b/src/main/DataRequest/ChangeCompleteState.test.ts
@@ -28,9 +28,13 @@ describe("changeCompleteState", () => {
       const r = changeCompleteState("2026-01-01 My simple todo", true);
       expect(r).toMatch(/^x \d{4}-\d{2}-\d{2} 2026-01-01/);
     });
-    it("adds creation date if nonexistent", () => {
+    it("does not add creation date if nonexistent", () => {
       const r = changeCompleteState("My simple todo", true);
-      expect(r).toMatch(/^x \d{4}-\d{2}-\d{2} \d{4}-\d{2}-\d{2}/);
+      expect(r).toMatch(/^x \d{4}-\d{2}-\d{2} My simple todo$/);
+    });
+    it("keeps existing creation date", () => {
+      const r = changeCompleteState("2026-01-01 My simple todo", true);
+      expect(r).toMatch(/^x \d{4}-\d{2}-\d{2} 2026-01-01 My simple todo$/);
     });
     it("moves priority to pri attribute", () => {
       const r = changeCompleteState("(B) My simple todo", true);

--- a/src/main/DataRequest/ChangeCompleteState.ts
+++ b/src/main/DataRequest/ChangeCompleteState.ts
@@ -19,7 +19,6 @@ function changeCompleteState(string: string, state: boolean): string {
       createRecurringTodo(content, recurrence.value);
     }
 
-    JsTodoTxtObject.setCreated(JsTodoTxtObject.created() ?? new Date());
     JsTodoTxtObject.setCompleted(new Date());
 
     const currentPriority = JsTodoTxtObject.priority();


### PR DESCRIPTION
### Problem

When marking a todo as complete, a creation date was automatically injected if none was present — even if the original todo never had one. This violated the [todo.txt format spec](https://github.com/todotxt/todo.txt), which states that creation dates are optional and should not be modified implicitly.

**Before:**
```
My simple todo  →  x 2026-05-21 2026-05-21 My simple todo
```

**After:**
```
My simple todo  →  x 2026-05-21 My simple todo
```

### Changes

**[ChangeCompleteState.ts](cci:7://file:///home/wallek/CascadeProjects/windsurf-project-3/sleek/src/main/DataRequest/ChangeCompleteState.ts:0:0-0:0)**
- Removed the `setCreated` call that was unconditionally setting a creation date (`created() ?? new Date()`) when completing a todo

**[ChangeCompleteState.test.ts](cci:7://file:///home/wallek/CascadeProjects/windsurf-project-3/sleek/src/main/DataRequest/ChangeCompleteState.test.ts:0:0-0:0)**
- Updated the existing test to assert that no creation date is injected when none was present
- Added a test to confirm that an existing creation date is preserved after completion