### PR TITLE
fix: refresh todo data after app-initiated writes

### DIFF
--- a/src/main/IpcHandlers.test.ts
+++ b/src/main/IpcHandlers.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IpcMainEvent } from "electron";
+import { ipcHandlers } from "./IpcHandlers";
+
+const mocks = vi.hoisted(() => ({
+  archiveTodos: vi.fn(),
+  changeCompleteState: vi.fn(),
+  createTodoObject: vi.fn(),
+  dataRequest: vi.fn(),
+  handleError: vi.fn(),
+  removeLineFromFile: vi.fn(),
+  writeSingleTodoToFile: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  ipcMain: {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+  shell: {
+    openExternal: vi.fn(),
+    showItemInFolder: vi.fn(),
+  },
+}));
+
+vi.mock("./DataRequest/ChangeCompleteState", () => ({
+  changeCompleteState: mocks.changeCompleteState,
+}));
+
+vi.mock("./Stores", () => ({
+  ColorsStore: {},
+  FiltersStore: {},
+  NotificationsStore: {},
+  SettingsStore: {},
+}));
+
+vi.mock("./DataRequest/DataRequest", () => ({
+  dataRequest: mocks.dataRequest,
+  searchString: "active search",
+}));
+
+vi.mock("./DataRequest/CreateTodoObjects", () => ({
+  createTodoObject: mocks.createTodoObject,
+}));
+
+vi.mock("./File/Write", () => ({
+  removeLineFromFile: mocks.removeLineFromFile,
+  writeSingleTodoToFile: mocks.writeSingleTodoToFile,
+}));
+
+vi.mock("./File/Archive", () => ({
+  archiveTodos: mocks.archiveTodos,
+  checkArchiveReadiness: vi.fn(),
+}));
+
+vi.mock("./File/File", () => ({
+  activateFile: vi.fn(),
+  registerTodoFile: vi.fn(),
+  removeFile: vi.fn(),
+}));
+
+vi.mock("./File/Dialog", () => ({
+  createFile: vi.fn(),
+  openFile: vi.fn(),
+}));
+
+vi.mock("./Shared", () => ({
+  HandleError: mocks.handleError,
+}));
+
+vi.mock("./IpcMain", () => ({
+  handleDeleteFilterValue: vi.fn(),
+  handleRenameFilterValue: vi.fn(),
+}));
+
+const handlers = Object.fromEntries(
+  ipcHandlers.map(({ channel, handler }) => [channel, handler]),
+);
+
+function createEvent(): IpcMainEvent {
+  return {
+    reply: vi.fn(),
+  } as unknown as IpcMainEvent;
+}
+
+describe("mutation IPC handlers", () => {
+  const requestedData = { todoData: [] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.archiveTodos.mockReturnValue("Archived");
+    mocks.changeCompleteState.mockReturnValue("x Todo");
+    mocks.createTodoObject.mockReturnValue({
+      lineNumber: 2,
+      string: "Todo due:2026-08-01",
+    });
+    mocks.dataRequest.mockReturnValue(requestedData);
+  });
+
+  it.each([
+    {
+      name: "adding a todo",
+      channel: "writeSingleTodoToFile",
+      args: [-1, "New todo", false],
+      mutation: mocks.writeSingleTodoToFile,
+    },
+    {
+      name: "editing a todo",
+      channel: "writeSingleTodoToFile",
+      args: [2, "Edited todo", true],
+      mutation: mocks.writeSingleTodoToFile,
+    },
+    {
+      name: "deleting a todo",
+      channel: "removeLineFromFile",
+      args: [2],
+      mutation: mocks.removeLineFromFile,
+    },
+    {
+      name: "archiving todos",
+      channel: "archiveTodos",
+      args: [],
+      mutation: mocks.archiveTodos,
+    },
+  ])("refreshes requested data after $name", ({ channel, args, mutation }) => {
+    const event = createEvent();
+
+    handlers[channel](event, ...args);
+
+    expect(mutation).toHaveBeenCalled();
+    expect(mocks.dataRequest).toHaveBeenCalledWith("active search");
+    expect(event.reply).toHaveBeenCalledWith("requestData", requestedData);
+    expect(mutation.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.dataRequest.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("refreshes after persisting a todo object update", () => {
+    const event = createEvent();
+
+    handlers.updateTodoObject(event, 2, "Todo", "due", "2026-08-01");
+
+    expect(mocks.writeSingleTodoToFile).toHaveBeenCalledWith(
+      2,
+      "Todo due:2026-08-01",
+      true,
+    );
+    expect(mocks.dataRequest).toHaveBeenCalledWith("active search");
+    expect(event.reply).toHaveBeenCalledWith("requestData", requestedData);
+    expect(event.reply).toHaveBeenCalledWith("updateTodoObject", {
+      lineNumber: 2,
+      string: "Todo due:2026-08-01",
+    });
+  });
+
+  it("refreshes after persisting the final completion state", () => {
+    const event = createEvent();
+
+    handlers.toggleTodoComplete(event, 2, "Todo rec:1w", true);
+
+    expect(mocks.changeCompleteState).toHaveBeenCalledWith("Todo rec:1w", true);
+    expect(mocks.writeSingleTodoToFile).toHaveBeenCalledWith(
+      2,
+      "x Todo",
+      false,
+    );
+    expect(mocks.dataRequest).toHaveBeenCalledWith("active search");
+    expect(event.reply).toHaveBeenCalledWith("requestData", requestedData);
+    expect(
+      mocks.writeSingleTodoToFile.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.dataRequest.mock.invocationCallOrder[0]);
+  });
+
+  it("reports mutation errors without refreshing requested data", () => {
+    const event = createEvent();
+    const error = new Error("write failed");
+    mocks.removeLineFromFile.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    handlers.removeLineFromFile(event, 2);
+
+    expect(mocks.handleError).toHaveBeenCalledWith(error);
+    expect(event.reply).toHaveBeenCalledWith("responseFromMainProcess", error);
+    expect(mocks.dataRequest).not.toHaveBeenCalled();
+    expect(event.reply).not.toHaveBeenCalledWith(
+      "requestData",
+      expect.anything(),
+    );
+  });
+
+  it("reports refresh errors without emitting stale requested data", () => {
+    const event = createEvent();
+    const error = new Error("read failed");
+    mocks.dataRequest.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    handlers.writeSingleTodoToFile(event, 2, "Edited todo", true);
+
+    expect(mocks.writeSingleTodoToFile).toHaveBeenCalled();
+    expect(mocks.handleError).toHaveBeenCalledWith(error);
+    expect(event.reply).toHaveBeenCalledWith("responseFromMainProcess", error);
+    expect(event.reply).not.toHaveBeenCalledWith(
+      "requestData",
+      expect.anything(),
+    );
+  });
+});

--- a/src/main/IpcHandlers.ts
+++ b/src/main/IpcHandlers.ts
@@ -6,7 +6,7 @@ import {
   NotificationsStore,
   ColorsStore,
 } from "./Stores";
-import { dataRequest } from "./DataRequest/DataRequest";
+import { dataRequest, searchString } from "./DataRequest/DataRequest";
 import { createTodoObject } from "./DataRequest/CreateTodoObjects";
 import { writeSingleTodoToFile, removeLineFromFile } from "./File/Write";
 import { archiveTodos, checkArchiveReadiness } from "./File/Archive";
@@ -188,6 +188,11 @@ function handleDataRequest(event: IpcMainEvent, searchString: string): void {
   }
 }
 
+function refreshRequestedData(event: IpcMainEvent): void {
+  const requestedData = dataRequest(searchString);
+  event.reply("requestData", requestedData);
+}
+
 function handleWriteTodoToFile(
   event: IpcMainEvent,
   lineNumber: number,
@@ -196,6 +201,7 @@ function handleWriteTodoToFile(
 ): void {
   try {
     writeSingleTodoToFile(lineNumber, content, isEditMode);
+    refreshRequestedData(event);
   } catch (error) {
     if (error instanceof Error) {
       HandleError(error);
@@ -210,6 +216,7 @@ function handleRemoveLineFromFile(
 ): void {
   try {
     removeLineFromFile(lineNumber);
+    refreshRequestedData(event);
   } catch (error) {
     if (error instanceof Error) {
       HandleError(error);
@@ -234,6 +241,7 @@ function handleUpdateTodoObject(
     );
     if (lineNumber >= 0) {
       writeSingleTodoToFile(lineNumber, todoObject.string, true);
+      refreshRequestedData(event);
     }
     event.reply("updateTodoObject", todoObject);
   } catch (error) {
@@ -249,6 +257,7 @@ function handleUpdateTodoObject(
 function handleArchiveTodos(event: IpcMainEvent): void {
   try {
     const result = archiveTodos();
+    refreshRequestedData(event);
     event.reply("responseFromMainProcess", result);
   } catch (error) {
     if (error instanceof Error) {
@@ -313,6 +322,7 @@ function handleToggleTodoComplete(
   try {
     const updatedString = changeCompleteState(todoString, completeState);
     writeSingleTodoToFile(lineNumber, updatedString, false);
+    refreshRequestedData(event);
   } catch (error) {
     if (error instanceof Error) {
       HandleError(error);


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/ransome1/sleek/blob/main/CONTRIBUTING.md) guide.
- [x] I have added tests for my changes, where it makes sense.
- [x] I have run `npm run lint`, `npm run format`, `npm run typecheck`, and `npm run test` and all checks pass.
- [ ] Only for new features: The feature I'm adding has been discussed in an issue beforehand and I've referenced it in the commit and PR description.

## Description

Add one shared refresh step in `src/main/IpcHandlers.ts` that rebuilds `RequestedData` with the current search string and replies on the existing `requestData` channel after an app-initiated mutation has completed successfully. Invoke it from the todo creation/edit, completion toggle, deletion, object update, and archive handlers so sorting, grouping, filters, headers, and recurring-todo side effects are recalculated from the persisted file rather than patched optimistically in the renderer. Keep `src/main/File/Watcher.ts` responsible for changes made outside sleek; duplicate watcher notifications are harmless state replacements, while the direct IPC refresh removes filesystem latency from the app's own save-to-render path.

Todo mutations are persisted synchronously by the main process, but the mutation handlers do not send refreshed list data back to the renderer. Instead, the UI depends on Chokidar observing the resulting filesystem event; atomic replacement writes can make that notification late or absent on external, networked, or otherwise high-latency storage. The current `main` branch still has this dependency in the create/edit, complete, delete, and archive handlers, so the list can remain stale even though reopening the file shows the persisted change. The issue is repository-local and has a bounded correction in the main-process IPC flow.

Fixes #902
