### PR TITLE
Fix due: and t: parsing false-positives

### DIFF
--- a/src/main/Date.ts
+++ b/src/main/Date.ts
@@ -65,22 +65,22 @@ export interface DateAttributes {
 export function extractSpeakingDates(body: string): DateAttributes {
   const expressions = [
     {
-      pattern: /(?<=\b)due:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g,
+      pattern: /(?:^|\s)due:(?!\d{4}-\d{2}-\d{2})(.*?)(?=[^\s]:|$)/g,
       key: "due:",
       type: "relative" as DateType,
     },
     {
-      pattern: /(?<=\b)due:(\d{4}-\d{2}-\d{2})/g,
+      pattern: /(?:^|\s)due:(\d{4}-\d{2}-\d{2})/g,
       key: "due:",
       type: "absolute" as DateType,
     },
     {
-      pattern: /(?<=\b)t:(?!(\d{4}-\d{2}-\d{2}))(.*?)(?=[^\s]:|$)/g,
+      pattern: /(?:^|\s)t:(?!\d{4}-\d{2}-\d{2})(.*?)(?=[^\s]:|$)/g,
       key: "t:",
       type: "relative" as DateType,
     },
     {
-      pattern: /(?<=\b)t:(\d{4}-\d{2}-\d{2})/g,
+      pattern: /(?:^|\s)t:(\d{4}-\d{2}-\d{2})/g,
       key: "t:",
       type: "absolute" as DateType,
     },
@@ -102,10 +102,10 @@ export function extractSpeakingDates(body: string): DateAttributes {
   };
 
   for (const expression of expressions) {
-    const regex = new RegExp(`(${expression.pattern.source})`);
-    const match = body.match(regex);
+    const regex = new RegExp(expression.pattern);
+    const match = regex.exec(body);
     if (match) {
-      const attributeValue = match[0].slice(expression.key.length);
+      const attributeValue = match[1];
       const dateAttribute = processDateWithSugar(
         attributeValue,
         expression.type,

--- a/src/renderer/Grid/Renderer.tsx
+++ b/src/renderer/Grid/Renderer.tsx
@@ -33,7 +33,7 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
     }[] = [
       {
         pattern: new RegExp(
-          `t:${todoObject.tString?.replace(/\s/g, "\\s")}`,
+          `(?:^|\\s)t:${todoObject.tString?.replace(/\s/g, "\\s")}`,
           "g",
         ),
         type: "t",
@@ -41,24 +41,24 @@ const RendererComponent: React.FC<RendererComponentProps> = memo(
       },
       {
         pattern: new RegExp(
-          `due:${todoObject.dueString?.replace(/\s/g, "\\s")}`,
+          `(?:^|\\s)due:${todoObject.dueString?.replace(/\s/g, "\\s")}`,
           "g",
         ),
         type: "due",
         key: "due:",
       },
-      { pattern: /@(\S+)/, type: "contexts", key: "@" },
+      { pattern: /(?:^|\s)@(\S+)/, type: "contexts", key: "@" },
       { pattern: /(?:^|\s)\+(\S+)/, type: "projects", key: "+" },
-      { pattern: /\bh:1\b/, type: "hidden", key: "h:1" },
-      { pattern: /\bpm:(\d+)/, type: "pm", key: "pm:" },
-      { pattern: /\brec:([^ ]+)/, type: "rec", key: "rec:" },
+      { pattern: /(?:^|\s)h:1\b/, type: "hidden", key: "h:1" },
+      { pattern: /(?:^|\s)pm:(\d+)/, type: "pm", key: "pm:" },
+      { pattern: /(?:^|\s)rec:([^ ]+)/, type: "rec", key: "rec:" },
       {
-        pattern: /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/\S+)/,
+        pattern: /\b([a-zA-Z][a-zA-Z0-9+.-]*:\/\/\S+)/,
         type: "url",
         key: "url",
       },
       {
-        pattern: /\b(?!(?:due|t|pm|rec|h|pri):)\w+:[^\s)]+/,
+        pattern: /(?:^|\s)(?!(?:due|t|pm|rec|h|pri):)[\w-]+:[^\s)]+/,
         type: "custom-tag",
         key: "custom-tag",
       },


### PR DESCRIPTION
Keys like foo-due: and foo-t: were parsed as due and t dates respectively, which is wrong. They should be parsed as custom tags. Refined the regexes a bit to prevent these.

Fixes #910
